### PR TITLE
[codex] Complete schema validation and Phase 3 snippets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 - `README_frontend_migration_plan.md` — текущий статус закрытого migration scope и список guardrails, которые нельзя откатывать.
 - `frontend-target-architecture.md` — целевой архитектурный контракт фронтенда в текущем репозитории.
 - `frontend-feature-api.md` — правила для feature API, registry и compat-слоя.
+- `config-schema-ux-roadmap.md` — roadmap по развитию UX вокруг схем Xray JSON и Mihomo YAML: schema enrichment, semantic validation, snippets, quick fixes и guided flows.
 - `frontend-page-inventory.md` — человекочитаемая карта страниц и freeze-правила для source graph.
 - `frontend-build-workflow.md` — актуальный install/build/verify workflow и связь с CI/archive workflows.
 - `adr/0001-frontend-esm-bootstrap.md` — архитектурное решение про build-managed ESM bootstrap.

--- a/docs/config-schema-ux-roadmap.md
+++ b/docs/config-schema-ux-roadmap.md
@@ -1,0 +1,412 @@
+# Roadmap: UX для схем Xray и Mihomo
+
+## Назначение
+
+Этот документ описывает практический roadmap, как превратить уже существующую
+поддержку схем Xray JSON и Mihomo YAML в действительно дружелюбный редактор
+конфигов, понятный даже новичку.
+
+Цель не только в том, чтобы валидировать конфиг, но и в том, чтобы помогать
+пользователю собирать правильный конфиг почти без внешней документации.
+
+## Что уже есть
+
+В проекте уже заложена хорошая база:
+
+- JSON Schema для Xray-фрагментов в `static/schemas/*.json`
+- YAML Schema для Mihomo в `static/schemas/mihomo-config.schema.json`
+- schema hover и completion в CodeMirror 6
+- schema hover и completion в Monaco
+- editor-level validation для JSON/JSONC и YAML
+- более богатые hover-подсказки для Xray JSON и в CM6, и в Monaco
+
+Этого уже достаточно для опытного пользователя. Основной оставшийся разрыв в
+UX сейчас не в валидации, а в сценарии "как правильно собрать рабочий блок с
+нуля".
+
+## North Star
+
+Новичок должен уметь:
+
+1. выбрать задачу вроде "добавить VLESS Reality proxy" или "создать url-test group";
+2. вставить минимальный корректный блок одним действием;
+3. получать направляющие подсказки по следующим обязательным полям;
+4. видеть понятные объяснения ошибок человеческим языком;
+5. применять типовые исправления в один клик.
+
+Иными словами, редактор должен работать не как "строгий валидатор", а как
+"помощник по сборке конфига".
+
+## Принципы
+
+- Лучше предотвращать ошибки, чем только подчёркивать их красным.
+- Лучше вставлять готовый рабочий каркас, чем пустой объект.
+- Лучше объяснять простыми словами, чем только терминами схемы.
+- Лучше давать мягкие предупреждения для сомнительных конфигов и жёсткие ошибки
+  только для действительно поломанных состояний.
+- UX для Xray и Mihomo должен быть максимально единым, где это возможно.
+- Источник истины должен быть один: сначала schema, затем semantic-слой, и
+  только потом точечный UI-hardcode.
+
+## Главные пробелы
+
+Сейчас schema-based UX всё ещё плохо покрывает то, что важнее всего для
+начинающего пользователя:
+
+- cross-reference валидацию между именованными сущностями;
+- task-oriented snippets и готовые шаблоны блоков;
+- quick fixes для типовых ошибок;
+- semantic-проверки совместимости связанных полей;
+- пояснения и примеры "для человека";
+- flow-level helpers, которые собирают рабочий блок, а не только подсказывают
+  отдельное значение.
+
+## Roadmap
+
+## Phase 1: Обогащение схем
+
+Приоритет: максимальный
+
+Цель: сделать hover и completion полезнее без смены общей модели работы редактора.
+
+### Scope
+
+- расширить `description` у важных полей так, чтобы оно объясняло:
+  - что делает поле;
+  - когда оно обычно нужно;
+  - когда его обычно можно не трогать;
+- добавить больше `examples` для:
+  - transport options;
+  - routing rules;
+  - proxy groups;
+  - DNS-блоков;
+  - sniffer-блоков;
+- добавить больше `default`, где runtime-default известен и стабилен;
+- добавить больше условных правил через:
+  - `if/then/else`;
+  - `dependentRequired`;
+  - `oneOf` с более понятным смыслом веток;
+- расширить `deprecated` и migration hints для устаревающих вариантов транспорта
+  и параметров.
+
+### UX-эффект
+
+- richer hover;
+- более полезный value completion;
+- более понятные дефолтные вставки;
+- меньше "формально валидных, но непонятных" подсказок.
+
+### Основные файлы
+
+- `xkeen-ui/static/schemas/xray-routing.schema.json`
+- `xkeen-ui/static/schemas/xray-config.schema.json`
+- `xkeen-ui/static/schemas/xray-inbounds.schema.json`
+- `xkeen-ui/static/schemas/xray-outbounds.schema.json`
+- `xkeen-ui/static/schemas/mihomo-config.schema.json`
+
+## Phase 2: Semantic validation поверх схем
+
+Приоритет: максимальный
+
+Цель: ловить ошибки, которые plain JSON Schema / YAML Schema выражают плохо или
+не выражают вовсе.
+
+### Scope
+
+- cross-reference validation для Xray:
+  - `outboundTag`;
+  - `balancerTag`;
+  - `ruleTag`;
+  - ссылки на реально существующие inbound/outbound tags;
+- cross-reference validation для Mihomo:
+  - `proxy-group.proxies`;
+  - `proxy-group.use`;
+  - `proxy-providers`;
+  - `rule-providers`;
+  - ссылки на реально существующие proxy/group/provider names;
+- semantic-проверки совместимости:
+  - transport-specific option blocks;
+  - TLS-only поля без TLS;
+  - protocol-specific поля на неподходящем протоколе;
+  - взаимоисключающие настройки;
+- warnings для подозрительных, но формально валидных конфигов:
+  - пустые группы;
+  - группы, ссылающиеся только на неизвестные прокси;
+  - provider без нормального refresh interval;
+  - route rule без действия или цели.
+
+### UX-эффект
+
+- меньше runtime-сюрпризов;
+- меньше ситуаций "валидно, но не работает";
+- более точные сообщения для ошибок в именах и несовместимых комбинациях полей.
+
+### Основные файлы
+
+- `xkeen-ui/static/js/ui/yaml_schema.js`
+- `xkeen-ui/static/js/vendor/codemirror_json_schema.js`
+- `xkeen-ui/static/js/ui/codemirror6_boot.js`
+- `xkeen-ui/static/js/ui/monaco_shared.js`
+- `xkeen-ui/static/js/features/routing.js`
+- `xkeen-ui/static/js/features/mihomo_panel.js`
+
+### Примечание
+
+Этот слой лучше реализовывать как отдельный semantic-pass поверх schema
+validation, а не пытаться насильно выразить всё через schema-хитрости.
+
+## Phase 3: Task-oriented snippets и шаблоны блоков
+
+Приоритет: максимальный
+
+Цель: дать пользователю возможность вставлять рабочие строительные блоки одним действием.
+
+### Scope
+
+- структурированные вставки для Xray:
+  - routing rule;
+  - direct/block/proxy outbound;
+  - balancer;
+  - observatory;
+  - transport settings;
+- структурированные вставки для Mihomo:
+  - proxy;
+  - proxy-group;
+  - proxy-provider;
+  - rule-provider;
+  - DNS block;
+  - sniffer block;
+  - TUN block;
+- предпочтение минимальным рабочим scaffold-блокам вместо пустых объектов;
+- по возможности адаптация шаблона под текущий контекст курсора.
+
+### Пример
+
+Вместо вставки:
+
+```yaml
+xhttp-opts: {}
+```
+
+вставлять:
+
+```yaml
+xhttp-opts:
+  path: /
+  mode: stream-one
+```
+
+А вместо вставки:
+
+```json
+"rules": []
+```
+
+давать возможность вставить:
+
+```json
+{
+  "type": "field",
+  "network": "udp",
+  "port": "443",
+  "outboundTag": "block"
+}
+```
+
+### UX-эффект
+
+- заметно быстрее собираются конфиги;
+- новичку не нужно собирать блок вручную из доков;
+- меньше синтаксических и структурных ошибок на старте.
+
+## Phase 4: Quick fixes
+
+Приоритет: высокий
+
+Цель: превращать диагностику в действие, а не просто в сообщение об ошибке.
+
+### Scope
+
+- quick fixes для типовых сценариев:
+  - добавить недостающее обязательное поле;
+  - вставить отсутствующий transport option block;
+  - заменить неизвестный tag на ближайший существующий;
+  - создать отсутствующий proxy-group или proxy-provider;
+  - заменить deprecated value на предпочтительный современный;
+  - автоматически обернуть scalar в array, если ожидается список;
+- показывать fixes в обоих редакторах там, где это возможно.
+
+### UX-эффект
+
+- снижение стоимости исправления ошибки;
+- лучшая обучаемость прямо внутри редактора;
+- меньше ручного исправления окружающего синтаксиса.
+
+### Точки интеграции
+
+- Monaco code actions / quick fixes;
+- CM6 toolbar action или inline fix affordance;
+- feature-level helper API для безопасных мутаций текста.
+
+## Phase 5: Beginner mode и explain-first hover
+
+Приоритет: высокий
+
+Цель: сделать редактор менее пугающим для пользователя без глубокого протокольного опыта.
+
+### Scope
+
+- опциональный beginner-oriented hover:
+  - простое объяснение;
+  - типичный use case;
+  - короткий пример;
+  - предупреждение о частой ошибке;
+- пояснение, почему поле показано именно здесь, особенно для conditional fields;
+- разделение diagnostics по уровням:
+  - error;
+  - warning;
+  - suggestion;
+- короткие recovery hints в самих diagnostics:
+  - что не так;
+  - что обычно нужно использовать вместо этого.
+
+### UX-эффект
+
+- меньше когнитивной перегрузки;
+- меньше походов во внешнюю документацию;
+- редактор начинает обучать прямо по ходу работы.
+
+## Phase 6: Guided builders и мастера
+
+Приоритет: средний по сложности, но очень высокий по долгосрочной UX-ценности
+
+Цель: дать возможность собирать типовые конфиги не только raw-редактированием.
+
+### Scope
+
+- мастера для типовых задач:
+  - добавить Xray routing rule;
+  - добавить Mihomo proxy;
+  - добавить Mihomo proxy-group;
+  - включить DNS fake-ip;
+  - включить sniffer;
+  - добавить VLESS Reality transport block;
+- запись результата обратно в raw editor;
+- генерация только schema-valid и stylistically consistent блоков.
+
+### UX-эффект
+
+- максимальный выигрыш для полного новичка;
+- заметное снижение порога входа;
+- сохранение совместимости с advanced raw editing workflow.
+
+## Рекомендуемый порядок внедрения
+
+Если делать поэтапно, то лучший порядок такой:
+
+1. Phase 2: semantic validation
+2. Phase 3: snippets и block templates
+3. Phase 4: quick fixes
+4. Phase 1: параллельное обогащение схем по мере необходимости
+5. Phase 5: beginner hover polish
+6. Phase 6: guided builders
+
+Причина:
+
+- semantic validation и snippets дают самый большой быстрый прирост UX;
+- quick fixes превращают ошибки в рабочий процесс;
+- guided builders дают максимальную ценность, но требуют уже хорошей базы.
+
+## Предлагаемый внутренний metadata-слой
+
+Чтобы не разносить UX-логику по каждому редактору отдельно, стоит добавить
+небольшой shared metadata-layer поверх schema definitions.
+
+Возможные custom metadata keys:
+
+- `x-ui-title`
+- `x-ui-group`
+- `x-ui-example`
+- `x-ui-insert-template`
+- `x-ui-required-when`
+- `x-ui-warning`
+- `x-ui-doc-link`
+
+Это должны быть editor-facing metadata, а не runtime semantics конфига.
+
+## Конкретные точки интеграции в проекте
+
+### Shared schema/runtime helpers
+
+- `xkeen-ui/static/js/vendor/codemirror_json_schema.js`
+- `xkeen-ui/static/js/ui/yaml_schema.js`
+- `xkeen-ui/static/js/ui/editor_schema.js`
+
+### Editor runtimes
+
+- `xkeen-ui/static/js/ui/codemirror6_boot.js`
+- `xkeen-ui/static/js/ui/monaco_shared.js`
+
+### Feature wiring
+
+- `xkeen-ui/static/js/features/routing.js`
+- `xkeen-ui/static/js/features/mihomo_panel.js`
+- `xkeen-ui/static/js/ui/json_editor_modal.js`
+
+### Возможные новые shared modules
+
+- `xkeen-ui/static/js/ui/schema_semantic_validation.js`
+- `xkeen-ui/static/js/ui/schema_quickfixes.js`
+- `xkeen-ui/static/js/ui/schema_snippets.js`
+
+## Acceptance criteria по этапам
+
+### После Phase 1
+
+- hover становится заметно богаче на всех основных блоках;
+- важные поля получают примеры и sane defaults;
+- transport-specific поля лучше ограничены через schema.
+
+### После Phase 2
+
+- неизвестные ссылки валидируются и объясняются явно;
+- несовместимые комбинации полей ловятся до сохранения;
+- diagnostics говорят, что нужно переименовать, создать или связать.
+
+### После Phase 3
+
+- новичок может вставлять типовые рабочие блоки без ручной сборки;
+- вставленный блок сразу синтаксически валиден.
+
+### После Phase 4
+
+- основные ошибки исправляются в одно действие;
+- quick fixes покрывают хотя бы top-10 частых проблем.
+
+### После Phase 5
+
+- diagnostics и hover-подсказки понятны без глубокого знания протоколов.
+
+### После Phase 6
+
+- новичок может собрать базовый рабочий конфиг через guided actions плюс
+  минимальные raw edits.
+
+## Non-goals
+
+- полностью заменить raw editing;
+- жёстко хардкодить всё знание о протоколах прямо в feature screens;
+- превращать schema layer в полноценный runtime emulator;
+- пытаться покрыть все экзотические edge cases раньше, чем отполированы типовые
+  beginner flows.
+
+## Короткая рекомендация
+
+Если брать только один короткий следующий milestone, то лучше всего делать:
+
+- semantic reference validation;
+- snippet insertion для типовых блоков;
+- quick fixes для top-10 ошибок.
+
+Именно эта комбинация даст больше реального UX-эффекта, чем просто дальнейшее
+расширение схем само по себе.

--- a/docs/config-schema-ux-roadmap.md
+++ b/docs/config-schema-ux-roadmap.md
@@ -174,11 +174,16 @@ validation, а не пытаться насильно выразить всё ч
   - proxy-group;
   - proxy-provider;
   - rule-provider;
-  - DNS block;
+  - DNS block (опционально, для Keenetic обычно не default path);
   - sniffer block;
-  - TUN block;
+  - TUN block (опционально, для Keenetic обычно не default path);
 - предпочтение минимальным рабочим scaffold-блокам вместо пустых объектов;
 - по возможности адаптация шаблона под текущий контекст курсора.
+
+### Keenetic note
+
+- для Keenetic не продвигать Mihomo DNS/TUN как стандартный стартовый сценарий: эти блоки обычно требуют отдельной перенастройки DNS/firewall/TUN на роутере;
+- для Xray DNS не предлагать "универсальный" DNS scaffold без оговорок: в Keenetic-сценарии лучше ориентироваться на DNS-over-VLESS flow по инструкции <https://jameszero.net/3398.htm>.
 
 ### Пример
 
@@ -377,6 +382,7 @@ xhttp-opts:
 
 - новичок может вставлять типовые рабочие блоки без ручной сборки;
 - вставленный блок сразу синтаксически валиден.
+- Keenetic-специфичные non-default блоки (Mihomo DNS/TUN, Xray DNS) помечены предупреждением и не выглядят как рекомендуемый baseline.
 
 ### После Phase 4
 

--- a/docs/frontend-page-inventory.json
+++ b/docs/frontend-page-inventory.json
@@ -337,6 +337,11 @@
           "lazy_features": []
         },
         {
+          "path": "static/js/ui/schema_snippets.js",
+          "globals": [],
+          "lazy_features": []
+        },
+        {
           "path": "static/js/features/routing_cards_namespace.js",
           "globals": [],
           "lazy_features": []

--- a/docs/frontend-page-inventory.json
+++ b/docs/frontend-page-inventory.json
@@ -622,6 +622,16 @@
           "lazy_features": []
         },
         {
+          "path": "static/js/vendor/codemirror_json_schema.js",
+          "globals": [],
+          "lazy_features": []
+        },
+        {
+          "path": "static/js/ui/schema_semantic_validation.js",
+          "globals": [],
+          "lazy_features": []
+        },
+        {
           "path": "static/js/util/strip_json_comments.js",
           "globals": [],
           "lazy_features": []
@@ -2519,6 +2529,11 @@
         },
         {
           "path": "static/js/vendor/codemirror_json_schema.js",
+          "globals": [],
+          "lazy_features": []
+        },
+        {
+          "path": "static/js/ui/schema_semantic_validation.js",
           "globals": [],
           "lazy_features": []
         },

--- a/tests/test_codemirror_json_schema_completion_runtime.py
+++ b/tests/test_codemirror_json_schema_completion_runtime.py
@@ -41,6 +41,8 @@ console.log(JSON.stringify(result ? result.options.map((option) => option.label)
         capture_output=True,
         cwd=str(ROOT),
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
 
@@ -82,6 +84,8 @@ console.log(JSON.stringify(diagnostics.map((item) => {{
         capture_output=True,
         cwd=str(ROOT),
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
 

--- a/tests/test_frontend_runtime_hotfixes.py
+++ b/tests/test_frontend_runtime_hotfixes.py
@@ -672,6 +672,31 @@ def test_mihomo_yaml_schema_runtime_is_wired_into_panel_editor():
     assert "mihomo-editor-yaml-badge" in template
 
 
+def test_phase2_semantic_validation_runtime_is_wired_into_mihomo_and_xray_editors():
+    semantic_runtime = Path('xkeen-ui/static/js/ui/schema_semantic_validation.js').read_text(encoding='utf-8')
+    yaml_schema_runtime = Path('xkeen-ui/static/js/ui/yaml_schema.js').read_text(encoding='utf-8')
+    codemirror_runtime = Path('xkeen-ui/static/js/ui/codemirror6_boot.js').read_text(encoding='utf-8')
+    json_schema_runtime = Path('xkeen-ui/static/js/vendor/codemirror_json_schema.js').read_text(encoding='utf-8')
+    routing_runtime = Path('xkeen-ui/static/js/features/routing.js').read_text(encoding='utf-8')
+
+    assert 'export function validateMihomoConfigSemantics(data, options = {})' in semantic_runtime
+    assert 'export function validateXrayRoutingSemantics(data, options = {})' in semantic_runtime
+    assert "import { validateMihomoConfigSemantics } from './schema_semantic_validation.js';" in yaml_schema_runtime
+    assert 'const semanticErrors = validateMihomoConfigSemantics(parsed, options);' in yaml_schema_runtime
+    assert "import { validateXrayRoutingSemantics } from '../ui/schema_semantic_validation.js';" in json_schema_runtime
+    assert 'const semanticErrors = resolveSemanticDiagnostics(options, {' in json_schema_runtime
+    assert 'buildJsoncPointerMap,' in json_schema_runtime
+    assert 'safeParseJson,' in json_schema_runtime
+    assert 'const schemaLintSource = jsonSchemaLinter(options);' in codemirror_runtime
+    assert "if (key === 'semanticValidation') {" in codemirror_runtime
+    assert 'semanticValidation: opts.semanticValidation || null,' in codemirror_runtime
+    assert "import { validateXrayRoutingSemantics } from '../ui/schema_semantic_validation.js';" in routing_runtime
+    assert 'function refreshRoutingSemanticContext(opts) {' in routing_runtime
+    assert 'function buildRoutingSemanticMarkers(text, diagnostics) {' in routing_runtime
+    assert "editor.setOption('semanticValidation', getRoutingSemanticValidationConfig());" in routing_runtime
+    assert 'const semanticDiagnostics = getRoutingSemanticDiagnostics(obj);' in routing_runtime
+
+
 def test_mihomo_schema_tracks_xhttp_transport_and_multiplexing_fields():
     schema = json.loads(Path('xkeen-ui/static/schemas/mihomo-config.schema.json').read_text(encoding='utf-8'))
     proxy_props = schema['definitions']['proxy']['properties']

--- a/tests/test_schema_semantic_validation_runtime.py
+++ b/tests/test_schema_semantic_validation_runtime.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_node_json(script: str) -> object:
+    if shutil.which("node") is None:
+        pytest.skip("node is not available in this environment")
+
+    result = subprocess.run(
+        ["node", "--input-type=module"],
+        input=script,
+        capture_output=True,
+        cwd=str(ROOT),
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    return json.loads(result.stdout.strip())
+
+
+def test_mihomo_yaml_runtime_reports_semantic_reference_errors():
+    doc = "\n".join([
+        "proxy-groups:",
+        "  - name: Auto",
+        "    type: select",
+        "    proxies: [ghost-node]",
+        "rules:",
+        "  - RULE-SET,missing-provider,Auto",
+        "",
+    ])
+
+    script = f"""
+import fs from 'node:fs';
+import {{ validateYamlTextAgainstSchema }} from './xkeen-ui/static/js/ui/yaml_schema.js';
+
+const schema = JSON.parse(fs.readFileSync('./xkeen-ui/static/schemas/mihomo-config.schema.json', 'utf8'));
+const result = validateYamlTextAgainstSchema({json.dumps(doc)}, schema, {{ maxErrors: 12 }});
+console.log(JSON.stringify({{
+  ok: !!result.ok,
+  diagnostics: (result.diagnostics || []).map((item) => ({{
+    path: item.path || '',
+    severity: item.severity || '',
+    message: item.message || '',
+  }})),
+}}));
+"""
+
+    payload = _run_node_json(script)
+    assert payload["ok"] is False
+    paths = [str(item["path"]) for item in payload["diagnostics"]]
+    messages = [str(item["message"]) for item in payload["diagnostics"]]
+
+    assert "proxy-groups[0].proxies[0]" in paths
+    assert "rules[0]" in paths
+    assert any("ghost-node" in message for message in messages)
+    assert any("missing-provider" in message for message in messages)
+
+
+def test_xray_semantic_validation_runtime_reports_missing_refs_and_duplicates():
+    script = """
+import { validateXrayRoutingSemantics } from './xkeen-ui/static/js/ui/schema_semantic_validation.js';
+
+const result = validateXrayRoutingSemantics({
+  routing: {
+    balancers: [
+      { tag: 'proxy', selector: [] }
+    ],
+    rules: [
+      { ruleTag: 'dup', outboundTag: 'ghost-out' },
+      { ruleTag: 'dup', balancerTag: 'ghost-balancer' },
+      { outboundTag: 'direct', balancerTag: 'proxy' }
+    ]
+  }
+}, {
+  knownOutboundTags: ['direct', 'block'],
+  knownInboundTags: ['tproxy']
+});
+
+console.log(JSON.stringify(result.map((item) => ({
+  pointer: item.pointer || '',
+  severity: item.severity || '',
+  message: item.message || '',
+}))));
+"""
+
+    payload = _run_node_json(script)
+    pointers = [str(item["pointer"]) for item in payload]
+    messages = [str(item["message"]) for item in payload]
+
+    assert "/routing/rules/0/outboundTag" in pointers
+    assert "/routing/rules/1/ruleTag" in pointers
+    assert "/routing/rules/1/balancerTag" in pointers
+    assert "/routing/rules/2/balancerTag" in pointers
+    assert any("ghost-out" in message for message in messages)
+    assert any("ghost-balancer" in message for message in messages)
+    assert any("dup" in message for message in messages)
+
+
+def test_codemirror_json_schema_linter_supports_xray_semantic_validation():
+    doc = "\n".join([
+        "{",
+        '  "routing": {',
+        '    "rules": [',
+        "      {",
+        '        "outboundTag": "ghost-out"',
+        "      }",
+        "    ]",
+        "  }",
+        "}",
+        "",
+    ])
+
+    script = f"""
+import fs from 'node:fs';
+import {{ EditorState }} from '@codemirror/state';
+import {{ json }} from '@codemirror/lang-json';
+import {{ jsonSchemaLinter, stateExtensions }} from './xkeen-ui/static/js/vendor/codemirror_json_schema.js';
+
+const schema = JSON.parse(fs.readFileSync('./xkeen-ui/static/schemas/xray-routing.schema.json', 'utf8'));
+const state = EditorState.create({{
+  doc: {json.dumps(doc)},
+  extensions: [json(), stateExtensions(schema)],
+}});
+const diagnostics = jsonSchemaLinter({{
+  semanticValidation: {{
+    kind: 'xray-routing',
+    options: {{
+      knownOutboundTags: ['direct', 'block'],
+    }},
+  }},
+}})({{ state }});
+
+console.log(JSON.stringify(diagnostics.map((item) => ({{
+  severity: item.severity || '',
+  source: item.source || '',
+  message: item.message || '',
+}}))));
+"""
+
+    payload = _run_node_json(script)
+    messages = [str(item["message"]) for item in payload]
+    sources = [str(item["source"]) for item in payload]
+
+    assert any("ghost-out" in message for message in messages)
+    assert any(source == "xray-semantic" for source in sources)

--- a/tests/test_schema_snippets_runtime.py
+++ b/tests/test_schema_snippets_runtime.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_node_json(script: str) -> object:
+    if shutil.which("node") is None:
+        pytest.skip("node is not available in this environment")
+
+    result = subprocess.run(
+        ["node", "--input-type=module"],
+        input=script,
+        capture_output=True,
+        cwd=str(ROOT),
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    return json.loads(result.stdout.strip())
+
+
+def test_editor_schema_resolves_snippet_providers_for_supported_targets():
+    payload = _run_node_json(
+        """
+import { resolveEditorSnippetProvider } from './xkeen-ui/static/js/ui/editor_schema.js';
+
+const routingProvider = resolveEditorSnippetProvider({
+  target: 'routing',
+  file: '05_routing.jsonc',
+  mode: 'jsonc',
+});
+const outboundsProvider = resolveEditorSnippetProvider({
+  target: 'outbounds',
+  file: '04_outbounds.json',
+  mode: 'jsonc',
+});
+const mihomoProvider = resolveEditorSnippetProvider({
+  target: 'mihomo',
+  file: 'config.yaml',
+  mode: 'yaml',
+});
+
+console.log(JSON.stringify({
+  routing: routingProvider ? routingProvider({ pointer: '/routing/rules/0' }).map((item) => item.id) : [],
+  outbounds: outboundsProvider ? outboundsProvider({ pointer: '/outbounds/0' }).map((item) => item.id) : [],
+  mihomo: mihomoProvider ? mihomoProvider({ path: [] }).map((item) => item.id) : [],
+}));
+"""
+    )
+
+    assert "xray-rule-block-domain" in payload["routing"]
+    assert "xray-rule-via-balancer" in payload["routing"]
+    assert "xray-outbound-direct" in payload["outbounds"]
+    assert "xray-outbound-vless-reality" in payload["outbounds"]
+    assert "mihomo-dns-block" in payload["mihomo"]
+    assert "mihomo-tun-block" in payload["mihomo"]
+    assert "mihomo-sniffer-block" in payload["mihomo"]
+
+
+def test_json_completion_runtime_surfaces_routing_rule_snippets_when_provider_is_wired():
+    labels = _run_node_json(
+        """
+import fs from 'node:fs';
+import { EditorState } from '@codemirror/state';
+import { CompletionContext } from '@codemirror/autocomplete';
+import { json } from '@codemirror/lang-json';
+import { stateExtensions, jsonCompletion } from './xkeen-ui/static/js/vendor/codemirror_json_schema.js';
+import { resolveEditorSnippetProvider } from './xkeen-ui/static/js/ui/editor_schema.js';
+
+const schema = JSON.parse(fs.readFileSync('./xkeen-ui/static/schemas/xray-routing.schema.json', 'utf8'));
+const marker = '__CURSOR__';
+const docWithMarker = [
+  '{',
+  '  "routing": {',
+  '    "rules": [',
+  '      {',
+  '        __CURSOR__',
+  '      }',
+  '    ]',
+  '  }',
+  '}',
+  '',
+].join('\\n');
+const pos = docWithMarker.indexOf(marker);
+const doc = docWithMarker.replace(marker, '');
+const provider = resolveEditorSnippetProvider({
+  target: 'routing',
+  file: '05_routing.jsonc',
+  mode: 'jsonc',
+});
+const state = EditorState.create({
+  doc,
+  extensions: [json(), stateExtensions(schema)],
+});
+const result = await jsonCompletion({
+  schemaKind: 'xray-routing',
+  snippetProvider: provider,
+})(new CompletionContext(state, pos, true));
+
+console.log(JSON.stringify(result ? result.options.map((option) => option.label) : []));
+"""
+    )
+
+    assert "📦 rule: block by domain" in labels
+    assert "📦 rule: direct by domain" in labels
+
+
+def test_xray_dns_snippet_points_to_keenetic_dns_over_vless_flow():
+    payload = _run_node_json(
+        """
+import { getXraySnippets } from './xkeen-ui/static/js/ui/schema_snippets.js';
+
+const dnsSnippet = getXraySnippets({
+  schemaKind: 'xray-config',
+  pointer: '/',
+}).find((item) => item && item.id === 'xray-config-dns');
+
+console.log(JSON.stringify({
+  label: dnsSnippet ? dnsSnippet.label : '',
+  warning: dnsSnippet ? dnsSnippet.warning : '',
+  documentation: dnsSnippet ? dnsSnippet.documentation : '',
+  insertText: dnsSnippet ? dnsSnippet.insertText : '',
+}));
+"""
+    )
+
+    assert "jameszero.net/3398.htm" in payload["warning"]
+    assert "dns-out outbound" in payload["warning"]
+    assert '"tag": "dns-in"' in payload["insertText"]
+    assert '"queryStrategy": "UseIP"' in payload["insertText"]
+
+
+def test_feature_editors_wire_schema_snippet_providers():
+    routing_src = (ROOT / "xkeen-ui" / "static" / "js" / "features" / "routing.js").read_text(encoding="utf-8")
+    mihomo_src = (ROOT / "xkeen-ui" / "static" / "js" / "features" / "mihomo_panel.js").read_text(encoding="utf-8")
+    modal_src = (ROOT / "xkeen-ui" / "static" / "js" / "ui" / "json_editor_modal.js").read_text(encoding="utf-8")
+    schema_src = (ROOT / "xkeen-ui" / "static" / "js" / "ui" / "editor_schema.js").read_text(encoding="utf-8")
+
+    assert "snippetProvider: getRoutingSnippetProvider()," in routing_src
+    assert "snippetProvider: getMihomoSnippetProvider()," in mihomo_src
+    assert "snippetProvider: getJsonEditorSnippetProvider()," in modal_src
+    assert "export function resolveEditorSnippetProvider(ctx)" in schema_src
+    assert "setEditorSnippetProvider(target, snippetProvider, o);" in schema_src

--- a/xkeen-ui/static/js/features/mihomo_panel.js
+++ b/xkeen-ui/static/js/features/mihomo_panel.js
@@ -19,7 +19,7 @@ import {
   getXkeenPageFlagsConfig,
   setXkeenPageConfigValue,
 } from './xkeen_runtime.js';
-import { loadEditorSchema } from '../ui/editor_schema.js';
+import { loadEditorSchema, resolveEditorSnippetProvider } from '../ui/editor_schema.js';
 
 let mihomoPanelModuleApi = null;
 
@@ -253,7 +253,17 @@ let mihomoPanelModuleApi = null;
         } catch (e) {}
         return null;
       },
+      snippetProvider: getMihomoSnippetProvider(),
     };
+  }
+
+  function getMihomoSnippetProvider() {
+    return resolveEditorSnippetProvider({
+      target: 'mihomo',
+      file: 'config.yaml',
+      mode: 'yaml',
+      feature: 'mihomo',
+    });
   }
 
   async function ensureMihomoSchemaDocument() {
@@ -473,6 +483,7 @@ let mihomoPanelModuleApi = null;
         insertSpaces: true,
         wordWrap: 'on',
         yamlAssist: getMihomoYamlAssistOptions(),
+        snippetProvider: getMihomoSnippetProvider(),
       });
       if (!_monaco) return null;
 
@@ -931,6 +942,7 @@ let mihomoPanelModuleApi = null;
       }),
       viewportMargin: 30,
       yamlAssist: getMihomoYamlAssistOptions(),
+      snippetProvider: getMihomoSnippetProvider(),
     });
 
     try {

--- a/xkeen-ui/static/js/features/routing.js
+++ b/xkeen-ui/static/js/features/routing.js
@@ -31,7 +31,7 @@ import {
   toastXkeen,
 } from './xkeen_runtime.js';
 import { stripJsonComments as stripJsonCommentsUtil } from '../util/strip_json_comments.js';
-import { applySchemaToEditor } from '../ui/editor_schema.js';
+import { applySchemaToEditor, resolveEditorSnippetProvider } from '../ui/editor_schema.js';
 import { validateXrayRoutingSemantics } from '../ui/schema_semantic_validation.js';
 
 (() => {
@@ -639,6 +639,16 @@ import { validateXrayRoutingSemantics } from '../ui/schema_semantic_validation.j
   function schemaStatusLabel(spec) {
     const label = spec && (spec.label || spec.title || spec.id);
     return String(label || '').trim();
+  }
+
+  function getRoutingSnippetProvider() {
+    const file = getActiveFragment() || getXkeenFilePath('routing', '');
+    return resolveEditorSnippetProvider({
+      target: _routingMode === 'routing' ? 'routing' : 'xray',
+      file,
+      mode: 'jsonc',
+      feature: 'routing',
+    });
   }
 
   function updateRoutingSchemaBadge(result) {
@@ -3953,6 +3963,7 @@ function closeHelp() {
       links: !initialLite,
       viewportMargin: initialLite ? PERF_LIMITS.viewportMarginLite : Infinity,
       semanticValidation: getRoutingSemanticValidationConfig(),
+      snippetProvider: getRoutingSnippetProvider(),
     });
 
     // Cosmetic class + toolbar
@@ -4723,6 +4734,7 @@ function closeHelp() {
           insertSpaces: true,
           performanceProfile: (_editorPerfProfile && _editorPerfProfile.lite) ? 'lite' : 'default',
           wordWrap: isMipsTarget() ? 'off' : 'on',
+          snippetProvider: getRoutingSnippetProvider(),
           onChange: () => {
             try { invalidateEditorSnapshot(); } catch (e) {}
             try { scheduleMonacoDiagnostics(); } catch (e) {}

--- a/xkeen-ui/static/js/features/routing.js
+++ b/xkeen-ui/static/js/features/routing.js
@@ -4,6 +4,11 @@ import { getRoutingShellApi as getRoutingShellModuleApi } from './routing_shell.
 import { getRoutingCardsApi as getRoutingCardsModuleApi } from './routing_cards.js';
 import { getBackupsApi as getBackupsModuleApi } from './backups.js';
 import {
+  buildJsoncPointerMap,
+  findDiagnosticMapping,
+  withDiagnosticContext,
+} from '../vendor/codemirror_json_schema.js';
+import {
   confirmXkeenAction,
   getXkeenCm6RuntimeApi,
   getXkeenCommandJobApi,
@@ -27,6 +32,7 @@ import {
 } from './xkeen_runtime.js';
 import { stripJsonComments as stripJsonCommentsUtil } from '../util/strip_json_comments.js';
 import { applySchemaToEditor } from '../ui/editor_schema.js';
+import { validateXrayRoutingSemantics } from '../ui/schema_semantic_validation.js';
 
 (() => {
   "use strict";
@@ -147,6 +153,14 @@ import { applySchemaToEditor } from '../ui/editor_schema.js';
 
   // Monaco diagnostics debounce (markers).
   let _monacoDiagTimer = null;
+  let _routingSemanticContext = {
+    key: '',
+    outboundTags: [],
+    inboundTags: [],
+    ready: false,
+  };
+  let _routingSemanticContextPromise = null;
+  let _routingSemanticContextTs = 0;
 
   // Monaco fullscreen (CSS-driven)
   let _monacoFsWired = false;
@@ -641,7 +655,176 @@ import { applySchemaToEditor } from '../ui/editor_schema.js';
       : 'JSON-схема пока не загружена для текущего редактора.');
   }
 
-async function applyRoutingSchemaToCodeMirror(cm, text) {
+  function readRememberedFragment(key) {
+    try {
+      const value = localStorage.getItem(String(key || ''));
+      return value ? String(value) : '';
+    } catch (e) {}
+    return '';
+  }
+
+  function collectConfigTagNames(config, field) {
+    const targetField = String(field || 'tag');
+    let list = null;
+    if (Array.isArray(config)) {
+      list = config;
+    } else if (config && typeof config === 'object') {
+      if (Array.isArray(config.outbounds)) list = config.outbounds;
+      else if (Array.isArray(config.inbounds)) list = config.inbounds;
+    }
+    if (!Array.isArray(list)) return [];
+    const values = [];
+    list.forEach((item) => {
+      if (!item || typeof item !== 'object') return;
+      const tag = String(item[targetField] || '').trim();
+      if (tag) values.push(tag);
+    });
+    return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b));
+  }
+
+  function buildRoutingSemanticContextKey() {
+    const outboundsFile = readRememberedFragment('xkeen.outbounds.fragment');
+    const inboundsFile = readRememberedFragment('xkeen.inbounds.fragment');
+    return `${outboundsFile}::${inboundsFile}`;
+  }
+
+  function getRoutingSemanticValidationConfig() {
+    return {
+      kind: 'xray-routing',
+      options: {
+        knownOutboundTags: Array.isArray(_routingSemanticContext.outboundTags) ? _routingSemanticContext.outboundTags.slice() : [],
+        knownInboundTags: Array.isArray(_routingSemanticContext.inboundTags) ? _routingSemanticContext.inboundTags.slice() : [],
+      },
+    };
+  }
+
+  function getRoutingSemanticDiagnostics(data) {
+    return validateXrayRoutingSemantics(data, getRoutingSemanticValidationConfig().options);
+  }
+
+  function createMonacoDocShim(text) {
+    const source = String(text || '');
+    return {
+      length: source.length,
+      lineAt(pos) {
+        const safe = Math.max(0, Math.min(source.length, Number(pos || 0)));
+        let number = 1;
+        let from = 0;
+        for (let index = 0; index < safe; index += 1) {
+          if (source.charCodeAt(index) === 10) {
+            number += 1;
+            from = index + 1;
+          }
+        }
+        return { number, from };
+      },
+    };
+  }
+
+  function buildRoutingSemanticMarkers(text, diagnostics) {
+    const raw = String(text || '');
+    const list = Array.isArray(diagnostics) ? diagnostics : [];
+    if (!list.length) return [];
+    const pointerMap = buildJsoncPointerMap(raw);
+    const doc = createMonacoDocShim(raw);
+    const monaco = window.monaco;
+    const severity = monaco && monaco.MarkerSeverity ? monaco.MarkerSeverity : {};
+    return list.map((item) => {
+      const pointer = String((item && item.pointer) || '');
+      const mapping = findDiagnosticMapping(pointerMap, pointer);
+      const start = mapping && Number.isFinite(mapping.valueFrom)
+        ? indexToMonacoLineCol(raw, mapping.valueFrom)
+        : { line: 1, col: 1 };
+      const end = mapping && Number.isFinite(mapping.valueTo)
+        ? indexToMonacoLineCol(raw, Math.max(Number(mapping.valueFrom || 0), Number(mapping.valueTo || 0)))
+        : { line: start.line, col: start.col + 1 };
+      return {
+        startLineNumber: Math.max(1, Number(start.line || 1)),
+        startColumn: Math.max(1, Number(start.col || 1)),
+        endLineNumber: Math.max(1, Number(end.line || start.line || 1)),
+        endColumn: Math.max(1, Number(end.col || start.col || 1)),
+        severity: item && item.severity === 'warning' ? (severity.Warning || 4) : (severity.Error || 8),
+        source: String((item && item.source) || 'xray-semantic'),
+        message: withDiagnosticContext(String((item && item.message) || 'Semantic validation error'), pointer, doc, mapping),
+      };
+    });
+  }
+
+  function applyRoutingSemanticValidationState() {
+    const semanticValidation = getRoutingSemanticValidationConfig();
+    try {
+      if (_cm && typeof _cm.setOption === 'function') {
+        _cm.setOption('semanticValidation', semanticValidation);
+      }
+    } catch (e) {}
+    try {
+      if (_engine === 'monaco' && _monaco) {
+        runMonacoDiagnostics();
+      }
+    } catch (e) {}
+  }
+
+  async function refreshRoutingSemanticContext(opts) {
+    const options = opts && typeof opts === 'object' ? opts : {};
+    const force = !!options.force;
+    const key = buildRoutingSemanticContextKey();
+    const now = Date.now();
+    if (!force && _routingSemanticContextPromise) return _routingSemanticContextPromise;
+    if (!force && _routingSemanticContext.key === key && (now - _routingSemanticContextTs) < 15000) {
+      return _routingSemanticContext;
+    }
+
+    const outboundsFile = readRememberedFragment('xkeen.outbounds.fragment');
+    const inboundsFile = readRememberedFragment('xkeen.inbounds.fragment');
+    const fetchConfig = async (url, file) => {
+      const suffix = file ? `?file=${encodeURIComponent(file)}` : '';
+      const response = await fetch(`${url}${suffix}`, { cache: 'no-store' });
+      if (!response.ok) return null;
+      const payload = await response.json().catch(() => null);
+      return payload && typeof payload === 'object' ? payload.config : null;
+    };
+
+    _routingSemanticContextPromise = Promise.all([
+      fetchConfig('/api/outbounds', outboundsFile),
+      fetchConfig('/api/inbounds', inboundsFile),
+    ]).then(([outboundsConfig, inboundsConfig]) => {
+      _routingSemanticContext = {
+        key,
+        outboundTags: collectConfigTagNames(outboundsConfig, 'tag'),
+        inboundTags: collectConfigTagNames(inboundsConfig, 'tag'),
+        ready: true,
+      };
+      _routingSemanticContextTs = Date.now();
+      applyRoutingSemanticValidationState();
+      return _routingSemanticContext;
+    }).catch(() => {
+      _routingSemanticContext = {
+        key,
+        outboundTags: [],
+        inboundTags: [],
+        ready: false,
+      };
+      _routingSemanticContextTs = Date.now();
+      applyRoutingSemanticValidationState();
+      return _routingSemanticContext;
+    }).finally(() => {
+      _routingSemanticContextPromise = null;
+    });
+
+    return _routingSemanticContextPromise;
+  }
+
+  function ensureRoutingSemanticContextFresh() {
+    const key = buildRoutingSemanticContextKey();
+    const stale = !key
+      ? !_routingSemanticContext.ready
+      : (_routingSemanticContext.key !== key || (Date.now() - _routingSemanticContextTs) >= 15000);
+    if (!stale) return false;
+    Promise.resolve(refreshRoutingSemanticContext({ force: false })).catch(() => null);
+    return true;
+  }
+
+  async function applyRoutingSchemaToCodeMirror(cm, text) {
     const editor = cm || _cm;
     if (!editor) {
       updateRoutingSchemaBadge(null);
@@ -656,6 +839,11 @@ async function applyRoutingSchemaToCodeMirror(cm, text) {
         text: typeof text === 'string' ? text : readCurrentEditorText(),
         feature: 'routing',
       });
+      try {
+        if (typeof editor.setOption === 'function') {
+          editor.setOption('semanticValidation', getRoutingSemanticValidationConfig());
+        }
+      } catch (e2) {}
       updateRoutingSchemaBadge(result);
       return result;
     } catch (e) {
@@ -679,6 +867,7 @@ async function applyRoutingSchemaToCodeMirror(cm, text) {
         text: typeof text === 'string' ? text : readCurrentEditorText(),
         feature: 'routing',
       });
+      try { ensureRoutingSemanticContextFresh(); } catch (e2) {}
       updateRoutingSchemaBadge(result);
       return result;
     } catch (e) {
@@ -2600,6 +2789,7 @@ function closeHelp() {
   function runMonacoDiagnostics() {
     // Validate JSONC (strip comments) and show errors as Monaco markers (no auto-fix).
     const raw = getEditorText();
+    try { ensureRoutingSemanticContextFresh(); } catch (e) {}
 
     if (!String(raw ?? '').trim()) {
       setError('Файл пуст. Введи корректный JSON.', null);
@@ -2626,13 +2816,21 @@ function closeHelp() {
 
     try {
       const obj = JSON.parse(cleaned);
-      setError('', null);
+      const semanticDiagnostics = getRoutingSemanticDiagnostics(obj);
+      const semanticMarkers = buildRoutingSemanticMarkers(raw, semanticDiagnostics);
+      const blockingSemantic = semanticDiagnostics.find((item) => item && item.severity !== 'warning') || null;
+      const semanticSummary = blockingSemantic ? String(blockingSemantic.message || '') : '';
+      if (semanticSummary) setError('Semantic error: ' + semanticSummary, null);
+      else setError('', null);
       clearJsonErrorLocation();
-      clearMonacoMarkers();
+      if (semanticMarkers.length) setMonacoMarkers(semanticMarkers);
+      else clearMonacoMarkers();
       _maybeUpdateModeFromParsed(obj);
-      _lastValidationState = { ok: true, message: 'JSON корректен' };
+      _lastValidationState = blockingSemantic
+        ? { ok: false, message: semanticSummary || 'Semantic validation failed' }
+        : { ok: true, message: 'JSON корректен' };
       try { updateEditorMetaStatus(); } catch (e) {}
-      return true;
+      return !blockingSemantic;
     } catch (e) {
       const loc = extractJsonErrorLocation(e, raw, sm);
       const msg = String(loc && loc.message ? loc.message : ((e && e.message) ? e.message : e));
@@ -2750,6 +2948,7 @@ function closeHelp() {
       try { updateEditorMetaStatus(); } catch (e) {}
 
       try { _setRoutingMode(_detectRoutingModeFromText(text), 'load'); } catch (e) {}
+      try { await refreshRoutingSemanticContext({ force: false }); } catch (e) {}
       try {
         if (_cm) await applyRoutingSchemaToCodeMirror(_cm, text);
       } catch (e) {}
@@ -3140,6 +3339,7 @@ function closeHelp() {
   }
 
   function validate() {
+    try { ensureRoutingSemanticContextFresh(); } catch (e) {}
     try {
       if (_engine === 'monaco' && _monaco) return runMonacoDiagnostics();
     } catch (e) {}
@@ -3156,13 +3356,19 @@ function closeHelp() {
 
     const analysis = getJsoncAnalysis(raw, { preciseLocation: true });
     if (analysis.ok) {
-      setError('', null);
+      const semanticDiagnostics = getRoutingSemanticDiagnostics(analysis.parsed);
+      const blockingSemantic = semanticDiagnostics.find((item) => item && item.severity !== 'warning') || null;
+      const semanticSummary = blockingSemantic ? String(blockingSemantic.message || '') : '';
+      if (semanticSummary) setError('Semantic error: ' + semanticSummary, null);
+      else setError('', null);
       clearJsonErrorLocation();
       _maybeUpdateModeFromParsed(analysis.parsed);
-      _lastValidationState = { ok: true, message: 'JSON is valid' };
+      _lastValidationState = blockingSemantic
+        ? { ok: false, message: semanticSummary || 'Semantic validation failed' }
+        : { ok: true, message: 'JSON is valid' };
       try { updateEditorMetaStatus(); } catch (e) {}
       try { syncCodeMirrorLintNow(); } catch (e2) {}
-      return true;
+      return !blockingSemantic;
     }
 
     const loc = analysis.loc || { line: 1, col: 1, index: 0 };
@@ -3746,6 +3952,7 @@ function closeHelp() {
       extraKeys,
       links: !initialLite,
       viewportMargin: initialLite ? PERF_LIMITS.viewportMarginLite : Infinity,
+      semanticValidation: getRoutingSemanticValidationConfig(),
     });
 
     // Cosmetic class + toolbar
@@ -4495,6 +4702,7 @@ function closeHelp() {
       resetMonacoHostDom(host);
 
       try {
+        try { await refreshRoutingSemanticContext({ force: false }); } catch (e) {}
         _monaco = await runtime.create(host, {
           value: readCurrentEditorText(),
           uri: getRoutingMonacoModelUri(),
@@ -4803,6 +5011,8 @@ function closeHelp() {
         await switchEngine(desired, { persist: false });
       }
     } catch (e) {}
+
+    try { await refreshRoutingSemanticContext({ force: false }); } catch (e) {}
 
     // Refresh CodeMirror if active.
     try {

--- a/xkeen-ui/static/js/ui/codemirror6_boot.js
+++ b/xkeen-ui/static/js/ui/codemirror6_boot.js
@@ -325,9 +325,13 @@ function jsonSchemaSyntaxAwareHover(opts) {
 
 function schemaExtensionFor(schema, opts) {
   if (!schema) return [];
+  const completionOpts = {
+    snippetProvider: opts && opts.snippetProvider ? opts.snippetProvider : null,
+    schemaKind: opts && opts.schemaKind ? opts.schemaKind : '',
+  };
   const extensions = [
     linter(jsonSchemaWithSyntaxLinter(opts), { needsRefresh: handleRefresh }),
-    jsonLanguage.data.of({ autocomplete: jsonCompletion() }),
+    jsonLanguage.data.of({ autocomplete: jsonCompletion(completionOpts) }),
     ...schemaStateExtensions(schema),
   ];
   if (isSchemaHoverEnabled(opts)) {
@@ -370,18 +374,27 @@ function yamlAssistExtensionFor(opts) {
     let schema = null;
     try { schema = getSchema(); } catch (e) {}
     if (!schema) return null;
-    const result = completeYamlTextFromSchema(context.state.doc.toString(), schema, { offset: context.pos });
+    const result = completeYamlTextFromSchema(context.state.doc.toString(), schema, {
+      offset: context.pos,
+      snippetProvider: opts && opts.snippetProvider ? opts.snippetProvider : null,
+    });
     if (!result || !Array.isArray(result.options) || !result.options.length) return null;
     return {
       from: Math.max(0, Number(result.from || 0)),
       to: Math.max(0, Number(result.to || result.from || 0)),
-      options: result.options.map((item) => ({
-        label: item.label,
-        type: item.type === 'property' ? 'property' : 'keyword',
-        detail: item.detail || '',
-        apply: item.insertText || item.label,
-        info: item.documentation && item.documentation.plain ? item.documentation.plain : '',
-      })),
+      options: result.options.map((item) => {
+        let type = 'keyword';
+        if (item.type === 'property') type = 'property';
+        else if (item.type === 'snippet') type = 'snippet';
+        return {
+          label: item.label,
+          type,
+          detail: item.detail || '',
+          apply: item.insertText || item.label,
+          info: item.documentation && item.documentation.plain ? item.documentation.plain : '',
+          boost: item.type === 'snippet' ? -5 : 0,
+        };
+      }),
     };
   };
 
@@ -1304,6 +1317,10 @@ function buildBridge(view, ctx) {
         options.semanticValidation = value || null;
         return bridge.refreshSchemaExtensions();
       }
+      if (key === 'snippetProvider') {
+        options.snippetProvider = value || null;
+        return bridge.refreshSchemaExtensions();
+      }
       return true;
     },
     getMode() { return getModeForCompat(); },
@@ -1355,6 +1372,7 @@ function createBridge(target, opts = {}) {
       extraKeys: (opts.extraKeys && typeof opts.extraKeys === 'object') ? opts.extraKeys : {},
       yamlAssist: opts.yamlAssist || null,
       semanticValidation: opts.semanticValidation || null,
+      snippetProvider: opts.snippetProvider || null,
     },
     languageCompartment: new Compartment(),
     readOnlyCompartment: new Compartment(),

--- a/xkeen-ui/static/js/ui/codemirror6_boot.js
+++ b/xkeen-ui/static/js/ui/codemirror6_boot.js
@@ -275,7 +275,7 @@ const jsonStrictExtension = [json(), jsoncEagerParser, Prec.highest(jsonStrictPu
 
 function jsonSchemaWithSyntaxLinter(opts) {
   const options = opts || {};
-  const schemaLintSource = jsonSchemaLinter();
+  const schemaLintSource = jsonSchemaLinter(options);
   return function jsonSchemaSyntaxAwareLintSource(view) {
     const source = view && view.state && view.state.doc ? view.state.doc.toString() : '';
     const syntax = makeJsonDiagnostics(source, {
@@ -1300,6 +1300,10 @@ function buildBridge(view, ctx) {
         options.yamlAssist = value || null;
         return dispatch({ effects: ctx.yamlAssistCompartment.reconfigure(yamlAssistExtensionFor(options)) });
       }
+      if (key === 'semanticValidation') {
+        options.semanticValidation = value || null;
+        return bridge.refreshSchemaExtensions();
+      }
       return true;
     },
     getMode() { return getModeForCompat(); },
@@ -1350,6 +1354,7 @@ function createBridge(target, opts = {}) {
       links: opts.links !== false,
       extraKeys: (opts.extraKeys && typeof opts.extraKeys === 'object') ? opts.extraKeys : {},
       yamlAssist: opts.yamlAssist || null,
+      semanticValidation: opts.semanticValidation || null,
     },
     languageCompartment: new Compartment(),
     readOnlyCompartment: new Compartment(),

--- a/xkeen-ui/static/js/ui/editor_schema.js
+++ b/xkeen-ui/static/js/ui/editor_schema.js
@@ -1,3 +1,8 @@
+import {
+  createMihomoSnippetProvider,
+  createXraySnippetProvider,
+} from './schema_snippets.js';
+
 const SCHEMA_URLS = Object.freeze({
   xray: '/static/schemas/xray-config.schema.json',
   xrayRouting: '/static/schemas/xray-routing.schema.json',
@@ -7,6 +12,13 @@ const SCHEMA_URLS = Object.freeze({
 });
 
 const _schemaCache = new Map();
+const _snippetProviderCache = Object.freeze({
+  'xray-config': createXraySnippetProvider('xray-config'),
+  'xray-routing': createXraySnippetProvider('xray-routing'),
+  'xray-inbounds': createXraySnippetProvider('xray-inbounds'),
+  'xray-outbounds': createXraySnippetProvider('xray-outbounds'),
+  mihomo: createMihomoSnippetProvider(),
+});
 
 function normalizeText(value) {
   return String(value || '').trim();
@@ -138,8 +150,44 @@ function setEditorSchema(editor, schema, ctx) {
   return false;
 }
 
+function setEditorSnippetProvider(editor, provider, ctx) {
+  const target = editor && editor.raw ? editor.raw : editor;
+  const runtime = getRuntime(ctx);
+  try {
+    if (runtime && typeof runtime.setSnippetProvider === 'function') return !!runtime.setSnippetProvider(target, provider || null);
+  } catch (e) {}
+  try {
+    if (target && typeof target.setSnippetProvider === 'function') return !!target.setSnippetProvider(provider || null);
+  } catch (e2) {}
+  try {
+    if (target && typeof target.setOption === 'function') return !!target.setOption('snippetProvider', provider || null);
+  } catch (e3) {}
+  return false;
+}
+
+function normalizeSnippetKind(value) {
+  const raw = normalizeLower(value);
+  if (!raw) return '';
+  if (raw === 'xray') return 'xray-config';
+  return raw;
+}
+
+export function resolveEditorSnippetProvider(ctx) {
+  const o = ctx || {};
+  const explicitKind = normalizeSnippetKind(o.snippetKind || o.schemaKind);
+  if (explicitKind && _snippetProviderCache[explicitKind]) return _snippetProviderCache[explicitKind];
+
+  const inferredKind = normalizeSnippetKind(inferSchemaKind(o));
+  if (!inferredKind) return null;
+  return _snippetProviderCache[inferredKind] || null;
+}
+
 export function clearSchemaFromEditor(editor, ctx) {
-  return setEditorSchema(editor, null, ctx || {});
+  const target = editor && editor.raw ? editor.raw : editor;
+  const context = ctx || {};
+  const schemaCleared = setEditorSchema(target, null, context);
+  const snippetCleared = setEditorSnippetProvider(target, null, context);
+  return schemaCleared || snippetCleared;
 }
 
 export async function applySchemaToEditor(editor, ctx) {
@@ -170,12 +218,21 @@ export async function applySchemaToEditor(editor, ctx) {
     };
   }
   const ok = setEditorSchema(target, loaded.schema, o);
-  return { ok, skipped: false, spec, schema: loaded.schema };
+  const snippetProvider = resolveEditorSnippetProvider({
+    ...o,
+    schemaKind: spec.family === 'xray'
+      ? (spec.fragment ? `xray-${spec.fragment}` : 'xray-config')
+      : spec.family,
+  });
+  const snippetsOk = setEditorSnippetProvider(target, snippetProvider, o);
+  return { ok: ok || snippetsOk, skipped: false, spec, schema: loaded.schema, snippetProvider };
 }
 
 export const editorSchemaApi = Object.freeze({
   resolveEditorSchemaSpec,
+  resolveEditorSnippetProvider,
   loadEditorSchema,
   applySchemaToEditor,
   clearSchemaFromEditor,
+  setEditorSnippetProvider,
 });

--- a/xkeen-ui/static/js/ui/json_editor_modal.js
+++ b/xkeen-ui/static/js/ui/json_editor_modal.js
@@ -7,7 +7,11 @@ import {
   getXkeenFilePath,
   getXkeenPageFilesConfig,
 } from '../features/xkeen_runtime.js';
-import { applySchemaToEditor, clearSchemaFromEditor } from './editor_schema.js';
+import {
+  applySchemaToEditor,
+  clearSchemaFromEditor,
+  resolveEditorSnippetProvider,
+} from './editor_schema.js';
 
 (() => {
   // JSON editor modal for 03_inbounds.json / 04_outbounds.json
@@ -354,6 +358,16 @@ import { applySchemaToEditor, clearSchemaFromEditor } from './editor_schema.js';
   function schemaStatusLabel(spec) {
     const label = spec && (spec.label || spec.title || spec.id);
     return String(label || '').trim();
+  }
+
+  function getJsonEditorSnippetProvider() {
+    if (!_currentTarget) return null;
+    return resolveEditorSnippetProvider({
+      target: _currentTarget,
+      file: activeFileParam(_currentTarget),
+      mode: 'jsonc',
+      feature: 'json-modal',
+    });
   }
 
   function updateJsonEditorSchemaBadge(result) {
@@ -710,6 +724,7 @@ import { applySchemaToEditor, clearSchemaFromEditor } from './editor_schema.js';
         'Shift-Ctrl-H': 'replaceAll',
       },
       viewportMargin: Infinity,
+      snippetProvider: getJsonEditorSnippetProvider(),
     });
 
     try {
@@ -749,6 +764,7 @@ import { applySchemaToEditor, clearSchemaFromEditor } from './editor_schema.js';
       tabSize: 2,
       insertSpaces: true,
       wordWrap: 'on',
+      snippetProvider: getJsonEditorSnippetProvider(),
     });
 
     try { await applyCurrentSchemaToMonaco(initialText); } catch (e) {}
@@ -1023,9 +1039,10 @@ import { applySchemaToEditor, clearSchemaFromEditor } from './editor_schema.js';
     if (modal) hideModal(modal, 'json_editor_close');
     try { clearDirtyListener(); } catch (e) {}
     try { if (_cm) clearSchemaFromEditor(_cm, { feature: 'json-modal' }); } catch (e) {}
+    try { if (_monaco) clearSchemaFromEditor(_monaco, { feature: 'json-modal' }); } catch (e2) {}
     try { updateJsonEditorSchemaBadge(null); } catch (e) {}
-    try { if (_cm && typeof _cm.clearDiagnostics === 'function') _cm.clearDiagnostics(); } catch (e2) {}
-    try { clearTargetDirtyState(target); } catch (e3) {}
+    try { if (_cm && typeof _cm.clearDiagnostics === 'function') _cm.clearDiagnostics(); } catch (e3) {}
+    try { clearTargetDirtyState(target); } catch (e4) {}
     setError('');
     _currentTarget = null;
     _savedText = '';

--- a/xkeen-ui/static/js/ui/monaco_shared.js
+++ b/xkeen-ui/static/js/ui/monaco_shared.js
@@ -1,5 +1,5 @@
 import { isXkeenMipsRuntime } from '../features/xkeen_runtime.js';
-import { buildJsonSchemaHoverInfo } from '../vendor/codemirror_json_schema.js';
+import { buildJsonSchemaHoverInfo, buildJsoncPointerMap } from '../vendor/codemirror_json_schema.js';
 import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_schema.js';
 
 (() => {
@@ -26,8 +26,10 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
     customContextMenuCleanupByEditor: typeof WeakMap !== 'undefined' ? new WeakMap() : null,
     customContextMenuClipboardShadow: '',
     yamlAssistByModel: typeof WeakMap !== 'undefined' ? new WeakMap() : null,
+    snippetProvidersByModel: typeof WeakMap !== 'undefined' ? new WeakMap() : null,
     jsonHoverProvidersInstalled: false,
     yamlAssistProvidersInstalled: false,
+    jsonSnippetProvidersInstalled: false,
   };
   const _CUSTOM_CONTEXT_MENU_CLEANUP_KEY = '__xkMonacoCustomContextMenuCleanup';
 
@@ -1437,9 +1439,76 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
   function _monacoCompletionKind(monaco, item) {
     try {
       if (item && item.type === 'property') return monaco.languages.CompletionItemKind.Field;
+      if (item && item.type === 'snippet') return monaco.languages.CompletionItemKind.Snippet;
       return monaco.languages.CompletionItemKind.Value;
     } catch (e) {}
     return 12;
+  }
+
+  function _setModelSnippetProvider(model, provider) {
+    if (!model) return;
+    if (_state.snippetProvidersByModel) {
+      try {
+        if (provider) _state.snippetProvidersByModel.set(model, provider);
+        else _state.snippetProvidersByModel.delete(model);
+        return;
+      } catch (e) {}
+    }
+    try {
+      if (provider) model.__xkSnippetProvider = provider;
+      else delete model.__xkSnippetProvider;
+    } catch (e) {}
+  }
+
+  function _getModelSnippetProvider(model) {
+    if (!model) return null;
+    if (_state.snippetProvidersByModel) {
+      try { return _state.snippetProvidersByModel.get(model) || null; } catch (e) {}
+    }
+    try { return model.__xkSnippetProvider || null; } catch (e) {}
+    return null;
+  }
+
+  function _resolveJsoncPointerAtOffset(text, offset) {
+    try {
+      const map = buildJsoncPointerMap(String(text || ''));
+      if (!map || typeof map.forEach !== 'function') return '';
+      const safeOffset = Math.max(0, Number(offset || 0));
+      let bestPointer = '';
+      let bestSpan = Infinity;
+      map.forEach((range, pointer) => {
+        const from = Math.max(0, Number(range && range.valueFrom || 0));
+        const to = Math.max(from, Number(range && range.valueTo || from));
+        if (safeOffset < from || safeOffset > to) return;
+        const span = to - from;
+        if (span < bestSpan) {
+          bestSpan = span;
+          bestPointer = String(pointer || '');
+        }
+      });
+      return bestPointer;
+    } catch (e) {}
+    return '';
+  }
+
+  function _invokeJsonSnippetProvider(provider, model, position) {
+    if (!provider || !model || typeof model.getOffsetAt !== 'function') return [];
+    let text = '';
+    try { text = model.getValue() || ''; } catch (e) { text = ''; }
+    let offset = 0;
+    try { offset = model.getOffsetAt(position); } catch (e) { offset = 0; }
+    const pointer = _resolveJsoncPointerAtOffset(text, offset);
+    let snippets = null;
+    try {
+      const fn = typeof provider === 'function'
+        ? provider
+        : (provider && typeof provider.getSnippets === 'function' ? (ctx) => provider.getSnippets(ctx) : null);
+      if (!fn) return [];
+      snippets = fn({ text, offset, pointer, model, position, language: 'json' });
+    } catch (e) {
+      snippets = null;
+    }
+    return Array.isArray(snippets) ? snippets : [];
   }
 
   function _ensureYamlAssistProviders(monaco) {
@@ -1452,8 +1521,10 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
         const schema = _resolveYamlAssistSchema(assist);
         if (!schema || !model || typeof model.getOffsetAt !== 'function') return { suggestions: [] };
 
+        const snippetProvider = _getModelSnippetProvider(model) || (assist && assist.snippetProvider) || null;
         const result = completeYamlTextFromSchema(model.getValue(), schema, {
           offset: model.getOffsetAt(position),
+          snippetProvider,
         });
         if (!result || !Array.isArray(result.options) || !result.options.length) return { suggestions: [] };
 
@@ -1462,18 +1533,30 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
         const range = new monaco.Range(start.lineNumber, start.column, end.lineNumber, end.column);
 
         return {
-          suggestions: result.options.map((item, index) => ({
-            label: item.label,
-            kind: _monacoCompletionKind(monaco, item),
-            insertText: item.insertText || item.label,
-            detail: item.detail || '',
-            documentation: item.documentation && item.documentation.markdown
-              ? { value: item.documentation.markdown }
-              : (item.documentation && item.documentation.plain ? item.documentation.plain : ''),
-            range,
-            sortText: `${item.type === 'property' ? '0' : '1'}-${String(index).padStart(4, '0')}-${item.label}`,
-            filterText: item.label,
-          })),
+          suggestions: result.options.map((item, index) => {
+            const isSnippet = item.type === 'snippet';
+            const insertText = isSnippet
+              ? (item.monacoSnippet || item.insertText || item.label)
+              : (item.insertText || item.label);
+            const base = {
+              label: item.label,
+              kind: _monacoCompletionKind(monaco, item),
+              insertText,
+              detail: item.detail || '',
+              documentation: item.documentation && item.documentation.markdown
+                ? { value: item.documentation.markdown }
+                : (item.documentation && item.documentation.plain ? item.documentation.plain : ''),
+              range,
+              sortText: `${isSnippet ? '9' : (item.type === 'property' ? '0' : '1')}-${String(index).padStart(4, '0')}-${item.label}`,
+              filterText: item.label,
+            };
+            if (isSnippet) {
+              try {
+                base.insertTextRules = monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet;
+              } catch (e) {}
+            }
+            return base;
+          }),
         };
       },
     });
@@ -1498,6 +1581,54 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
     });
 
     _state.yamlAssistProvidersInstalled = true;
+  }
+
+  function _ensureJsonSnippetProviders(monaco) {
+    if (!monaco || !monaco.languages || _state.jsonSnippetProvidersInstalled) return;
+
+    const provider = {
+      triggerCharacters: ['/', '"', ' ', ','],
+      provideCompletionItems(model, position) {
+        if (!_supportsJsonSchemaOnModel(model) || !model || typeof model.getOffsetAt !== 'function') {
+          return { suggestions: [] };
+        }
+        const snippetProvider = _getModelSnippetProvider(model);
+        if (!snippetProvider) return { suggestions: [] };
+
+        const snippets = _invokeJsonSnippetProvider(snippetProvider, model, position);
+        if (!snippets.length) return { suggestions: [] };
+
+        const offset = (() => { try { return model.getOffsetAt(position); } catch (e) { return 0; } })();
+        const start = model.getPositionAt(offset);
+        const end = model.getPositionAt(offset);
+        const range = new monaco.Range(start.lineNumber, start.column, end.lineNumber, end.column);
+
+        const suggestions = snippets
+          .filter((item) => item && item.label && (item.insertText || item.monacoSnippet))
+          .map((item, index) => {
+            const insertText = item.monacoSnippet || item.insertText || '';
+            const docParts = [];
+            if (item.documentation) docParts.push(String(item.documentation));
+            if (item.warning) docParts.push(`⚠ ${String(item.warning)}`);
+            const docValue = docParts.join('\n\n');
+            return {
+              label: `📦 ${String(item.label)}`,
+              kind: monaco.languages.CompletionItemKind.Snippet,
+              insertText,
+              insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+              detail: String(item.detail || 'snippet'),
+              documentation: docValue ? { value: docValue } : '',
+              range,
+              sortText: `9-${String(index).padStart(4, '0')}-${item.label}`,
+              filterText: `snippet ${item.label}`,
+            };
+          });
+        return { suggestions };
+      },
+    };
+    try { monaco.languages.registerCompletionItemProvider('json', provider); } catch (e) {}
+    try { monaco.languages.registerCompletionItemProvider('jsonc', provider); } catch (e) {}
+    _state.jsonSnippetProvidersInstalled = true;
   }
 
   function _ensureJsonHoverProviders(monaco) {
@@ -1554,6 +1685,7 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
       // Ensure the requested language is registered (best-effort).
       try { await _ensureLanguage(monaco, language); } catch (e) {}
       try { _ensureJsonHoverProviders(monaco); } catch (e) {}
+      try { _ensureJsonSnippetProviders(monaco); } catch (e) {}
       try { _ensureYamlAssistProviders(monaco); } catch (e) {}
       try { applyTheme(monaco); } catch (e) {}
       try { wireThemeSync(monaco); } catch (e) {}
@@ -1622,6 +1754,7 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
           monaco.editor.setModelLanguage(model, runtimeLanguage);
         }
         if (model) _setModelYamlAssist(model, (language === 'yaml' && o.yamlAssist) ? o.yamlAssist : null);
+        if (model) _setModelSnippetProvider(model, o.snippetProvider || null);
       } catch (e) {}
       try {
         if (model && o.schema) _setModelJsonSchema(model, o.schema, monaco);
@@ -1634,6 +1767,12 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
             return _setModelJsonSchema(model, currentSchema, monaco);
           };
           editor.getSchema = () => currentSchema || null;
+          editor.setSnippetProvider = (provider) => {
+            if (!model) return false;
+            _setModelSnippetProvider(model, provider || null);
+            return true;
+          };
+          editor.getSnippetProvider = () => (model ? _getModelSnippetProvider(model) : null);
         }
       } catch (e) {}
 
@@ -1678,6 +1817,7 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
             editor.onDidDispose(() => {
               try { unsubscribeUiSettings(); } catch (e2) {}
               try { if (model) _setModelYamlAssist(model, null); } catch (e3) {}
+              try { if (model) _setModelSnippetProvider(model, null); } catch (e3b) {}
               try { if (model) _setModelJsonSchema(model, null, monaco); } catch (e4) {}
               try { if (ownedModel && typeof ownedModel.dispose === 'function') ownedModel.dispose(); } catch (e5) {}
             });
@@ -1699,6 +1839,7 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
         if (editor && typeof editor.onDidDispose === 'function') {
           editor.onDidDispose(() => {
             try { if (model) _setModelYamlAssist(model, null); } catch (e2) {}
+            try { if (model) _setModelSnippetProvider(model, null); } catch (e2b) {}
             try { if (model) _setModelJsonSchema(model, null, monaco); } catch (e3) {}
             try { if (ownedModel && typeof ownedModel.dispose === 'function') ownedModel.dispose(); } catch (e4) {}
           });
@@ -1801,5 +1942,12 @@ import { completeYamlTextFromSchema, hoverYamlTextFromSchema } from './yaml_sche
     layoutOnVisible,
     toFacade,
     uninstallCustomContextMenu,
+    setModelSnippetProvider(model, provider) {
+      _setModelSnippetProvider(model, provider || null);
+      return true;
+    },
+    getModelSnippetProvider(model) {
+      return _getModelSnippetProvider(model);
+    },
   };
 })();

--- a/xkeen-ui/static/js/ui/schema_semantic_validation.js
+++ b/xkeen-ui/static/js/ui/schema_semantic_validation.js
@@ -1,0 +1,603 @@
+function asString(value) {
+  return String(value == null ? '' : value);
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function cleanName(value) {
+  const text = asString(value).trim();
+  return text || '';
+}
+
+function uniqueSorted(values) {
+  return Array.from(new Set((Array.isArray(values) ? values : []).map(cleanName).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+function previewNames(values, limit = 8) {
+  const list = uniqueSorted(values);
+  if (!list.length) return '';
+  const shown = list.slice(0, Math.max(1, Number(limit || 0)));
+  const tail = list.length - shown.length;
+  return tail > 0 ? `${shown.join(', ')} ... (+${tail})` : shown.join(', ');
+}
+
+function pushDiagnostic(target, item) {
+  if (!item || typeof item !== 'object') return;
+  const message = cleanName(item.message);
+  if (!message) return;
+  target.push({
+    severity: item.severity === 'warning' ? 'warning' : 'error',
+    source: cleanName(item.source) || 'semantic-validation',
+    message,
+    path: Array.isArray(item.path) ? item.path.slice() : [],
+    pointer: cleanName(item.pointer),
+    code: cleanName(item.code),
+  });
+}
+
+function pointerFromPath(path) {
+  const parts = Array.isArray(path) ? path : [];
+  if (!parts.length) return '';
+  return parts.reduce((acc, part) => {
+    const value = String(part == null ? '' : part).replace(/~/g, '~0').replace(/\//g, '~1');
+    return `${acc}/${value}`;
+  }, '');
+}
+
+function pathFromPointer(pointer) {
+  const text = cleanName(pointer);
+  if (!text || text === '/') return [];
+  return text.split('/').slice(1).map((part) => {
+    const value = part.replace(/~1/g, '/').replace(/~0/g, '~');
+    return /^\d+$/.test(value) ? Number(value) : value;
+  });
+}
+
+function createYamlDiagnostic(path, message, options = {}) {
+  const nextPath = Array.isArray(path) ? path.slice() : [];
+  return {
+    path: nextPath,
+    message: cleanName(message),
+    severity: options.severity === 'warning' ? 'warning' : 'error',
+    source: cleanName(options.source) || 'mihomo-semantic',
+    code: cleanName(options.code),
+  };
+}
+
+function createJsonDiagnostic(pointer, message, options = {}) {
+  const nextPointer = cleanName(pointer);
+  return {
+    pointer: nextPointer,
+    path: pathFromPointer(nextPointer),
+    message: cleanName(message),
+    severity: options.severity === 'warning' ? 'warning' : 'error',
+    source: cleanName(options.source) || 'xray-semantic',
+    code: cleanName(options.code),
+  };
+}
+
+function collectNamedItems(list, nameKey = 'name') {
+  const names = [];
+  const seen = new Map();
+  (Array.isArray(list) ? list : []).forEach((item, index) => {
+    if (!isPlainObject(item)) return;
+    const name = cleanName(item[nameKey]);
+    if (!name) return;
+    names.push(name);
+    if (!seen.has(name)) {
+      seen.set(name, { index, item });
+    }
+  });
+  return { names: uniqueSorted(names), seen };
+}
+
+function collectProviderNames(mapLike) {
+  if (!isPlainObject(mapLike)) return [];
+  return uniqueSorted(Object.keys(mapLike));
+}
+
+const MIHOMO_RESERVED_PROXY_NAMES = Object.freeze({
+  DIRECT: true,
+  REJECT: true,
+  REJECT_DROP: true,
+  PASS: true,
+  COMPATIBLE: true,
+});
+
+function isReservedMihomoTarget(name) {
+  const key = cleanName(name).toUpperCase();
+  return !!MIHOMO_RESERVED_PROXY_NAMES[key];
+}
+
+function splitTopLevelRuleParts(rule) {
+  const text = cleanName(rule);
+  if (!text) return [];
+  const parts = [];
+  let chunk = '';
+  let depth = 0;
+  let inQuote = '';
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const ch = text.charAt(index);
+    if (escaped) {
+      chunk += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      chunk += ch;
+      escaped = true;
+      continue;
+    }
+    if (inQuote) {
+      chunk += ch;
+      if (ch === inQuote) inQuote = '';
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      chunk += ch;
+      inQuote = ch;
+      continue;
+    }
+    if (ch === '(') {
+      depth += 1;
+      chunk += ch;
+      continue;
+    }
+    if (ch === ')') {
+      depth = Math.max(0, depth - 1);
+      chunk += ch;
+      continue;
+    }
+    if (ch === ',' && depth === 0) {
+      parts.push(chunk.trim());
+      chunk = '';
+      continue;
+    }
+    chunk += ch;
+  }
+  if (chunk.trim() || !parts.length) parts.push(chunk.trim());
+  return parts.filter((item) => item !== '');
+}
+
+function extractRuleSetNames(rule) {
+  const text = cleanName(rule);
+  const names = [];
+  const pattern = /\bRULE-SET,([^,\s)]+)/g;
+  let match;
+  while ((match = pattern.exec(text))) {
+    const name = cleanName(match[1]);
+    if (name) names.push(name);
+  }
+  return uniqueSorted(names);
+}
+
+function resolveMihomoRuleTarget(parts) {
+  const list = Array.isArray(parts) ? parts : [];
+  const skip = {
+    'no-resolve': true,
+    src: true,
+    dst: true,
+  };
+  for (let index = list.length - 1; index >= 1; index -= 1) {
+    const token = cleanName(list[index]);
+    if (!token) continue;
+    if (skip[token.toLowerCase()]) continue;
+    return token;
+  }
+  return '';
+}
+
+function expectedProviderFields(kind, type) {
+  const nextType = cleanName(type);
+  if (nextType === 'http') {
+    return {
+      required: ['url', 'path'],
+      warn: ['interval'],
+      noun: kind === 'rule' ? 'rule-provider' : 'proxy-provider',
+    };
+  }
+  if (nextType === 'file') {
+    return {
+      required: ['path'],
+      warn: [],
+      noun: kind === 'rule' ? 'rule-provider' : 'proxy-provider',
+    };
+  }
+  if (nextType === 'inline') {
+    return {
+      required: ['payload'],
+      warn: [],
+      noun: kind === 'rule' ? 'rule-provider' : 'proxy-provider',
+    };
+  }
+  return { required: [], warn: [], noun: kind === 'rule' ? 'rule-provider' : 'proxy-provider' };
+}
+
+function validateProviderShape(target, mapLike, pathPrefix, kind) {
+  if (!isPlainObject(mapLike)) return;
+  Object.keys(mapLike).forEach((name) => {
+    const item = mapLike[name];
+    if (!isPlainObject(item)) return;
+    const itemPath = [pathPrefix, name];
+    const type = cleanName(item.type);
+    const spec = expectedProviderFields(kind, type);
+    spec.required.forEach((field) => {
+      if (item[field] == null || (typeof item[field] === 'string' && !cleanName(item[field]))) {
+        pushDiagnostic(target, createYamlDiagnostic(itemPath, `${spec.noun} \`${name}\` типа \`${type}\` ожидает поле \`${field}\`.`, {
+          source: 'mihomo-semantic',
+          code: `${kind}-provider-missing-${field}`,
+        }));
+      }
+    });
+    spec.warn.forEach((field) => {
+      if (item[field] == null || (typeof item[field] === 'string' && !cleanName(item[field]))) {
+        pushDiagnostic(target, createYamlDiagnostic(itemPath, `${spec.noun} \`${name}\` типа \`${type}\` обычно лучше указывать с полем \`${field}\`, чтобы обновления не зависели от runtime defaults.`, {
+          severity: 'warning',
+          source: 'mihomo-semantic',
+          code: `${kind}-provider-missing-${field}-warning`,
+        }));
+      }
+    });
+  });
+}
+
+function validateMihomoProxyCompat(target, proxies) {
+  (Array.isArray(proxies) ? proxies : []).forEach((proxy, index) => {
+    if (!isPlainObject(proxy)) return;
+    const path = ['proxies', index];
+    const type = cleanName(proxy.type);
+    const network = cleanName(proxy.network);
+    const tls = proxy.tls === true;
+
+    const networkBlocks = [
+      ['ws-opts', 'ws'],
+      ['grpc-opts', 'grpc'],
+      ['h2-opts', 'h2'],
+      ['xhttp-opts', 'xhttp'],
+    ];
+    networkBlocks.forEach(([field, expected]) => {
+      if (!isPlainObject(proxy[field])) return;
+      if (network && network === expected) return;
+      pushDiagnostic(target, createYamlDiagnostic(path.concat(field), `Блок \`${field}\` имеет смысл только при \`network: ${expected}\`. Сейчас указано \`${network || 'tcp'}\`.`, {
+        source: 'mihomo-semantic',
+        code: `proxy-network-${field}`,
+      }));
+    });
+
+    if (!tls) {
+      ['servername', 'fingerprint', 'client-fingerprint', 'reality-opts'].forEach((field) => {
+        const value = proxy[field];
+        if (value == null) return;
+        if (typeof value === 'string' && !cleanName(value)) return;
+        if (isPlainObject(value) && !Object.keys(value).length) return;
+        pushDiagnostic(target, createYamlDiagnostic(path.concat(field), `Поле \`${field}\` обычно используется только вместе с \`tls: true\`. Сейчас TLS выключен.`, {
+          severity: 'warning',
+          source: 'mihomo-semantic',
+          code: `proxy-tls-${field}`,
+        }));
+      });
+    }
+
+    if (Object.prototype.hasOwnProperty.call(proxy, 'alterId') && type && type !== 'vmess') {
+      pushDiagnostic(target, createYamlDiagnostic(path.concat('alterId'), `Поле \`alterId\` ожидается у \`type: vmess\`, а сейчас указан \`${type}\`.`, {
+        severity: 'warning',
+        source: 'mihomo-semantic',
+        code: 'proxy-type-alterid',
+      }));
+    }
+
+    if (Object.prototype.hasOwnProperty.call(proxy, 'flow') && cleanName(proxy.flow) && type && type !== 'vless') {
+      pushDiagnostic(target, createYamlDiagnostic(path.concat('flow'), `Поле \`flow\` обычно используется только у \`type: vless\`, а сейчас указан \`${type}\`.`, {
+        severity: 'warning',
+        source: 'mihomo-semantic',
+        code: 'proxy-type-flow',
+      }));
+    }
+  });
+}
+
+export function validateMihomoConfigSemantics(data, options = {}) {
+  const diagnostics = [];
+  if (!isPlainObject(data)) return diagnostics;
+
+  const proxies = Array.isArray(data.proxies) ? data.proxies : [];
+  const proxyGroups = Array.isArray(data['proxy-groups']) ? data['proxy-groups'] : [];
+  const proxyProviders = isPlainObject(data['proxy-providers']) ? data['proxy-providers'] : {};
+  const ruleProviders = isPlainObject(data['rule-providers']) ? data['rule-providers'] : {};
+  const rules = Array.isArray(data.rules) ? data.rules : [];
+
+  const proxyInfo = collectNamedItems(proxies, 'name');
+  const groupInfo = collectNamedItems(proxyGroups, 'name');
+  const proxyProviderNames = collectProviderNames(proxyProviders);
+  const ruleProviderNames = collectProviderNames(ruleProviders);
+
+  const knownProxyTargets = new Set([
+    ...proxyInfo.names,
+    ...groupInfo.names,
+  ]);
+
+  validateMihomoProxyCompat(diagnostics, proxies);
+  validateProviderShape(diagnostics, proxyProviders, 'proxy-providers', 'proxy');
+  validateProviderShape(diagnostics, ruleProviders, 'rule-providers', 'rule');
+
+  Object.keys(proxyProviders).forEach((name) => {
+    const provider = proxyProviders[name];
+    if (!isPlainObject(provider)) return;
+    const proxyName = cleanName(provider.proxy);
+    if (!proxyName || isReservedMihomoTarget(proxyName)) return;
+    if (!knownProxyTargets.has(proxyName)) {
+      pushDiagnostic(diagnostics, createYamlDiagnostic(['proxy-providers', name, 'proxy'], `proxy-provider \`${name}\` ссылается на proxy/group \`${proxyName}\`, но такого имени нет в \`proxies\` или \`proxy-groups\`.`, {
+        source: 'mihomo-semantic',
+        code: 'proxy-provider-proxy-missing',
+      }));
+    }
+  });
+
+  Object.keys(ruleProviders).forEach((name) => {
+    const provider = ruleProviders[name];
+    if (!isPlainObject(provider)) return;
+    const proxyName = cleanName(provider.proxy);
+    if (!proxyName || isReservedMihomoTarget(proxyName)) return;
+    if (!knownProxyTargets.has(proxyName)) {
+      pushDiagnostic(diagnostics, createYamlDiagnostic(['rule-providers', name, 'proxy'], `rule-provider \`${name}\` ссылается на proxy/group \`${proxyName}\`, но такого имени нет в \`proxies\` или \`proxy-groups\`.`, {
+        source: 'mihomo-semantic',
+        code: 'rule-provider-proxy-missing',
+      }));
+    }
+  });
+
+  proxyGroups.forEach((group, index) => {
+    if (!isPlainObject(group)) return;
+    const path = ['proxy-groups', index];
+    const groupName = cleanName(group.name);
+    const type = cleanName(group.type);
+    const proxiesList = Array.isArray(group.proxies) ? group.proxies : [];
+    const useList = Array.isArray(group.use) ? group.use : [];
+    const includeAll = group['include-all'] === true || group['include-all-proxies'] === true || group['include-all-providers'] === true;
+
+    proxiesList.forEach((name, itemIndex) => {
+      const targetName = cleanName(name);
+      if (!targetName || isReservedMihomoTarget(targetName)) return;
+      if (groupName && targetName === groupName) {
+        pushDiagnostic(diagnostics, createYamlDiagnostic(path.concat('proxies', itemIndex), `Группа \`${groupName}\` ссылается сама на себя в \`proxies\`. Это обычно приводит к циклу выбора.`, {
+          severity: 'warning',
+          source: 'mihomo-semantic',
+          code: 'proxy-group-self-reference',
+        }));
+        return;
+      }
+      if (knownProxyTargets.has(targetName)) return;
+      pushDiagnostic(diagnostics, createYamlDiagnostic(path.concat('proxies', itemIndex), `Группа \`${groupName || `proxy-groups[${index}]`}\` ссылается на \`${targetName}\`, но такого proxy/group нет.`, {
+        source: 'mihomo-semantic',
+        code: 'proxy-group-target-missing',
+      }));
+    });
+
+    useList.forEach((name, itemIndex) => {
+      const providerName = cleanName(name);
+      if (!providerName) return;
+      if (proxyProviderNames.includes(providerName)) return;
+      pushDiagnostic(diagnostics, createYamlDiagnostic(path.concat('use', itemIndex), `Группа \`${groupName || `proxy-groups[${index}]`}\` использует proxy-provider \`${providerName}\`, но такого provider нет.`, {
+        source: 'mihomo-semantic',
+        code: 'proxy-group-provider-missing',
+      }));
+    });
+
+    if (!includeAll && !proxiesList.length && !useList.length) {
+      pushDiagnostic(diagnostics, createYamlDiagnostic(path, `Группа \`${groupName || `proxy-groups[${index}]`}\` не содержит ни \`proxies\`, ни \`use\`, ни include-all-флага. Выбрать в ней будет нечего.`, {
+        severity: 'warning',
+        source: 'mihomo-semantic',
+        code: 'proxy-group-empty',
+      }));
+    }
+
+    if (['url-test', 'fallback', 'load-balance'].includes(type) && !cleanName(group.url)) {
+      pushDiagnostic(diagnostics, createYamlDiagnostic(path, `Группа \`${groupName || `proxy-groups[${index}]`}\` типа \`${type}\` обычно ожидает поле \`url\` для проверки доступности узлов.`, {
+        severity: 'warning',
+        source: 'mihomo-semantic',
+        code: 'proxy-group-missing-url',
+      }));
+    }
+  });
+
+  rules.forEach((rule, index) => {
+    if (typeof rule !== 'string') return;
+    const path = ['rules', index];
+    const parts = splitTopLevelRuleParts(rule);
+    const providers = extractRuleSetNames(rule);
+    providers.forEach((name) => {
+      if (ruleProviderNames.includes(name)) return;
+      pushDiagnostic(diagnostics, createYamlDiagnostic(path, `Правило \`${rule}\` ссылается на rule-provider \`${name}\`, но такого provider нет в \`rule-providers\`.`, {
+        source: 'mihomo-semantic',
+        code: 'rule-provider-missing',
+      }));
+    });
+
+    if (parts.length < 2) return;
+    const targetName = resolveMihomoRuleTarget(parts);
+    if (!targetName) {
+      pushDiagnostic(diagnostics, createYamlDiagnostic(path, `Правило \`${rule}\` не указывает целевую proxy-group или proxy в конце строки.`, {
+        severity: 'warning',
+        source: 'mihomo-semantic',
+        code: 'rule-target-missing',
+      }));
+      return;
+    }
+    if (isReservedMihomoTarget(targetName)) return;
+    if (knownProxyTargets.has(targetName) || groupInfo.seen.has(targetName) || proxyInfo.seen.has(targetName)) return;
+    pushDiagnostic(diagnostics, createYamlDiagnostic(path, `Правило \`${rule}\` направляет трафик в \`${targetName}\`, но такого proxy/group нет.`, {
+      source: 'mihomo-semantic',
+      code: 'rule-target-not-found',
+    }));
+  });
+
+  return diagnostics;
+}
+
+function collectXrayTagsFromArray(list, field = 'tag') {
+  const tags = [];
+  (Array.isArray(list) ? list : []).forEach((item) => {
+    if (!isPlainObject(item)) return;
+    const tag = cleanName(item[field]);
+    if (tag) tags.push(tag);
+  });
+  return uniqueSorted(tags);
+}
+
+function getXrayRoutingShape(data) {
+  if (!isPlainObject(data)) return null;
+  if (isPlainObject(data.routing)) {
+    return {
+      routing: data.routing,
+      rulesPointer: '/routing/rules',
+      balancersPointer: '/routing/balancers',
+      outbounds: Array.isArray(data.outbounds) ? data.outbounds : [],
+      inbounds: Array.isArray(data.inbounds) ? data.inbounds : [],
+    };
+  }
+  if (Array.isArray(data.rules) || Array.isArray(data.balancers)) {
+    return {
+      routing: data,
+      rulesPointer: '/rules',
+      balancersPointer: '/balancers',
+      outbounds: Array.isArray(data.outbounds) ? data.outbounds : [],
+      inbounds: Array.isArray(data.inbounds) ? data.inbounds : [],
+    };
+  }
+  return null;
+}
+
+function collectXrayKnownTags(shape, options, kind) {
+  const directField = kind === 'outbound'
+    ? ['knownOutboundTags', 'outboundTags']
+    : ['knownInboundTags', 'inboundTags'];
+  const contextKeys = kind === 'outbound'
+    ? ['contextOutbounds', 'context', 'externalOutbounds']
+    : ['contextInbounds', 'context', 'externalInbounds'];
+  const docTags = kind === 'outbound'
+    ? collectXrayTagsFromArray(shape && shape.outbounds, 'tag')
+    : collectXrayTagsFromArray(shape && shape.inbounds, 'tag');
+  const out = [...docTags];
+
+  directField.forEach((key) => {
+    const list = options && Array.isArray(options[key]) ? options[key] : [];
+    out.push(...list);
+  });
+
+  contextKeys.forEach((key) => {
+    const value = options ? options[key] : null;
+    if (!value) return;
+    if (Array.isArray(value)) {
+      out.push(...value);
+      return;
+    }
+    if (isPlainObject(value) && Array.isArray(value[kind === 'outbound' ? 'outboundTags' : 'inboundTags'])) {
+      out.push(...value[kind === 'outbound' ? 'outboundTags' : 'inboundTags']);
+    }
+  });
+
+  return uniqueSorted(out);
+}
+
+function quoteRuleLabel(ruleTag, index) {
+  return ruleTag ? `Правило "${ruleTag}"` : `Правило routing.rules[${index}]`;
+}
+
+export function validateXrayRoutingSemantics(data, options = {}) {
+  const diagnostics = [];
+  const shape = getXrayRoutingShape(data);
+  if (!shape || !isPlainObject(shape.routing)) return diagnostics;
+
+  const routing = shape.routing;
+  const rules = Array.isArray(routing.rules) ? routing.rules : [];
+  const balancers = Array.isArray(routing.balancers) ? routing.balancers : [];
+  const balancerTags = collectXrayTagsFromArray(balancers, 'tag');
+  const outboundTags = collectXrayKnownTags(shape, options, 'outbound');
+  const inboundTags = collectXrayKnownTags(shape, options, 'inbound');
+  const seenRuleTags = new Map();
+
+  rules.forEach((rule, index) => {
+    if (!isPlainObject(rule)) return;
+    const rulePointer = `${shape.rulesPointer}/${index}`;
+    const ruleTag = cleanName(rule.ruleTag);
+    const outboundTag = cleanName(rule.outboundTag);
+    const balancerTag = cleanName(rule.balancerTag);
+    const inboundTagList = Array.isArray(rule.inboundTag) ? rule.inboundTag.map(cleanName).filter(Boolean) : [];
+
+    if (ruleTag) {
+      if (seenRuleTags.has(ruleTag)) {
+        const firstIndex = seenRuleTags.get(ruleTag);
+        pushDiagnostic(diagnostics, createJsonDiagnostic(`${rulePointer}/ruleTag`, `Имя ruleTag "${ruleTag}" уже используется в routing.rules[${firstIndex}]. Повторяющиеся ruleTag мешают понятной диагностике и сопровождению правил.`, {
+          severity: 'warning',
+          source: 'xray-semantic',
+          code: 'rule-tag-duplicate',
+        }));
+      } else {
+        seenRuleTags.set(ruleTag, index);
+      }
+    }
+
+    if (outboundTag && balancerTag) {
+      pushDiagnostic(diagnostics, createJsonDiagnostic(`${rulePointer}/balancerTag`, `${quoteRuleLabel(ruleTag, index)} одновременно указывает и outboundTag "${outboundTag}", и balancerTag "${balancerTag}". Обычно здесь нужен только один маршрут назначения.`, {
+        source: 'xray-semantic',
+        code: 'rule-multiple-targets',
+      }));
+    } else if (!outboundTag && !balancerTag) {
+      pushDiagnostic(diagnostics, createJsonDiagnostic(rulePointer, `${quoteRuleLabel(ruleTag, index)} не указывает ни outboundTag, ни balancerTag. Такое правило формально выглядит завершённым, но не задаёт направление маршрутизации.`, {
+        severity: 'warning',
+        source: 'xray-semantic',
+        code: 'rule-missing-target',
+      }));
+    }
+
+    if (outboundTag && outboundTags.length && !outboundTags.includes(outboundTag)) {
+      const available = previewNames(outboundTags);
+      pushDiagnostic(diagnostics, createJsonDiagnostic(`${rulePointer}/outboundTag`, `${quoteRuleLabel(ruleTag, index)} ссылается на outboundTag "${outboundTag}", но такого outbound нет.${available ? ` Сейчас доступны: ${available}.` : ''}`, {
+        source: 'xray-semantic',
+        code: 'outbound-tag-missing',
+      }));
+    }
+
+    if (balancerTag && !balancerTags.includes(balancerTag)) {
+      const available = previewNames(balancerTags);
+      pushDiagnostic(diagnostics, createJsonDiagnostic(`${rulePointer}/balancerTag`, `${quoteRuleLabel(ruleTag, index)} ссылается на balancerTag "${balancerTag}", но такого balancer нет.${available ? ` Сейчас доступны: ${available}.` : ''}`, {
+        source: 'xray-semantic',
+        code: 'balancer-tag-missing',
+      }));
+    }
+
+    inboundTagList.forEach((tag, inboundIndex) => {
+      if (!inboundTags.length || inboundTags.includes(tag)) return;
+      const available = previewNames(inboundTags);
+      pushDiagnostic(diagnostics, createJsonDiagnostic(`${rulePointer}/inboundTag/${inboundIndex}`, `${quoteRuleLabel(ruleTag, index)} ссылается на inboundTag "${tag}", но такого inbound нет.${available ? ` Сейчас доступны: ${available}.` : ''}`, {
+        source: 'xray-semantic',
+        code: 'inbound-tag-missing',
+      }));
+    });
+  });
+
+  balancers.forEach((balancer, index) => {
+    if (!isPlainObject(balancer)) return;
+    const tag = cleanName(balancer.tag);
+    const selector = Array.isArray(balancer.selector) ? balancer.selector.map(cleanName).filter(Boolean) : [];
+    if (!selector.length) {
+      pushDiagnostic(diagnostics, createJsonDiagnostic(`${shape.balancersPointer}/${index}`, `Balancer "${tag || index}" не содержит selector. Без selector ему будет нечего выбирать среди outbound тегов.`, {
+        severity: 'warning',
+        source: 'xray-semantic',
+        code: 'balancer-selector-empty',
+      }));
+    }
+  });
+
+  return diagnostics;
+}
+
+export const schemaSemanticValidationApi = Object.freeze({
+  validateMihomoConfigSemantics,
+  validateXrayRoutingSemantics,
+});

--- a/xkeen-ui/static/js/ui/schema_snippets.js
+++ b/xkeen-ui/static/js/ui/schema_snippets.js
@@ -1,0 +1,645 @@
+/**
+ * schema_snippets.js — task-oriented block templates для Xray JSON и Mihomo YAML.
+ *
+ * Используется из CM6 (через jsonCompletion/completeYamlTextFromSchema с опцией snippetProvider)
+ * и из Monaco (через registerCompletionItemProvider в monaco_shared.js).
+ *
+ * Источник сниппетов — плоские массивы, фильтруемые по контексту вставки (schemaKind/pointer/path).
+ * Каждый сниппет содержит insertText (для CM6) и monacoSnippet (с ${1:placeholder} tabstops).
+ *
+ * Keenetic-специфика: сниппеты DNS block и TUN block (Mihomo), DNS (Xray) содержат поле
+ * warning с напоминанием, что эти блоки обычно требуют особой настройки роутера
+ * и/или инструкции https://jameszero.net/3398.htm (для Xray DNS).
+ */
+
+const KEENETIC_XRAY_DNS_NOTE =
+  'На Keenetic Xray DNS обычно настраивают по инструкции https://jameszero.net/3398.htm: вместе с dns-out outbound, routing rules для портa 53 и domainStrategy на proxy/direct.';
+
+const KEENETIC_MIHOMO_DNS_NOTE =
+  'На Keenetic DNS-блок Mihomo редко используется напрямую: обычно требует перенастройки системного резолвера и firewall, иначе ломается разрешение имён для самого роутера.';
+
+const KEENETIC_MIHOMO_TUN_NOTE =
+  'На Keenetic TUN-блок Mihomo редко используется: требует включения TUN-режима в прошивке и корректных ip-rules/route таблиц, иначе роутер не маршрутизирует трафик.';
+
+/* ════════════════════════════════════════════════════════════
+ *  Xray · routing rules (вставка в массив rules)
+ * ════════════════════════════════════════════════════════════ */
+
+const XRAY_ROUTING_RULES_SNIPPETS = [
+  {
+    id: 'xray-rule-block-domain',
+    label: 'rule: block by domain',
+    detail: 'Xray · routing.rules[]',
+    documentation: 'Правило блокировки трафика к указанным доменам. Поддерживает exact-домены и ссылки geosite:*.',
+    insertText: '{\n  "type": "field",\n  "domain": [\n    "geosite:category-ads-all"\n  ],\n  "outboundTag": "block"\n}',
+    monacoSnippet: '{\n  "type": "field",\n  "domain": [\n    "${1:geosite:category-ads-all}"\n  ],\n  "outboundTag": "${2:block}"\n}$0',
+  },
+  {
+    id: 'xray-rule-block-ip',
+    label: 'rule: block by IP / CIDR',
+    detail: 'Xray · routing.rules[]',
+    documentation: 'Блокировка трафика на IP, CIDR или geoip:*.',
+    insertText: '{\n  "type": "field",\n  "ip": [\n    "geoip:private"\n  ],\n  "outboundTag": "block"\n}',
+    monacoSnippet: '{\n  "type": "field",\n  "ip": [\n    "${1:geoip:private}"\n  ],\n  "outboundTag": "${2:block}"\n}$0',
+  },
+  {
+    id: 'xray-rule-proxy-domain',
+    label: 'rule: proxy by domain',
+    detail: 'Xray · routing.rules[]',
+    documentation: 'Направить трафик по списку доменов через proxy/balancer outbound.',
+    insertText: '{\n  "type": "field",\n  "domain": [\n    "geosite:geolocation-!cn"\n  ],\n  "outboundTag": "proxy"\n}',
+    monacoSnippet: '{\n  "type": "field",\n  "domain": [\n    "${1:geosite:geolocation-!cn}"\n  ],\n  "outboundTag": "${2:proxy}"\n}$0',
+  },
+  {
+    id: 'xray-rule-direct-domain',
+    label: 'rule: direct by domain',
+    detail: 'Xray · routing.rules[]',
+    documentation: 'Пропустить трафик напрямую (freedom) по списку доменов.',
+    insertText: '{\n  "type": "field",\n  "domain": [\n    "geosite:private",\n    "geosite:ru"\n  ],\n  "outboundTag": "direct"\n}',
+    monacoSnippet: '{\n  "type": "field",\n  "domain": [\n    "${1:geosite:private}",\n    "${2:geosite:ru}"\n  ],\n  "outboundTag": "${3:direct}"\n}$0',
+  },
+  {
+    id: 'xray-rule-proxy-by-port',
+    label: 'rule: proxy by port',
+    detail: 'Xray · routing.rules[]',
+    documentation: 'Проксировать трафик по port/port-range (например TCP 443, UDP 443 — QUIC).',
+    insertText: '{\n  "type": "field",\n  "network": "tcp,udp",\n  "port": "443",\n  "outboundTag": "proxy"\n}',
+    monacoSnippet: '{\n  "type": "field",\n  "network": "${1|tcp,udp,tcp,udp|}",\n  "port": "${2:443}",\n  "outboundTag": "${3:proxy}"\n}$0',
+  },
+  {
+    id: 'xray-rule-proxy-by-process',
+    label: 'rule: proxy by process name',
+    detail: 'Xray · routing.rules[]',
+    documentation: 'Проксировать трафик конкретного процесса (по имени исполняемого файла).',
+    insertText: '{\n  "type": "field",\n  "process": [\n    "chrome.exe"\n  ],\n  "outboundTag": "proxy"\n}',
+    monacoSnippet: '{\n  "type": "field",\n  "process": [\n    "${1:chrome.exe}"\n  ],\n  "outboundTag": "${2:proxy}"\n}$0',
+  },
+  {
+    id: 'xray-rule-via-balancer',
+    label: 'rule: route via balancer',
+    detail: 'Xray · routing.rules[]',
+    documentation: 'Направить трафик в balancer вместо конкретного outbound.',
+    insertText: '{\n  "type": "field",\n  "domain": [\n    "geosite:geolocation-!cn"\n  ],\n  "balancerTag": "balancer-auto"\n}',
+    monacoSnippet: '{\n  "type": "field",\n  "domain": [\n    "${1:geosite:geolocation-!cn}"\n  ],\n  "balancerTag": "${2:balancer-auto}"\n}$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Xray · routing balancers (вставка в массив balancers)
+ * ════════════════════════════════════════════════════════════ */
+
+const XRAY_ROUTING_BALANCERS_SNIPPETS = [
+  {
+    id: 'xray-balancer-auto',
+    label: 'balancer: auto (observatory)',
+    detail: 'Xray · routing.balancers[]',
+    documentation: 'Автоматический balancer с observatory-стратегией. На Keenetic осторожно с количеством селекторов — 300+ узлов кладут роутер.',
+    insertText: '{\n  "tag": "balancer-auto",\n  "selector": [\n    "proxy-"\n  ],\n  "strategy": {\n    "type": "leastPing"\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:balancer-auto}",\n  "selector": [\n    "${2:proxy-}"\n  ],\n  "strategy": {\n    "type": "${3|leastPing,random,roundRobin,leastLoad|}"\n  }\n}$0',
+  },
+  {
+    id: 'xray-balancer-leastload',
+    label: 'balancer: leastLoad',
+    detail: 'Xray · routing.balancers[]',
+    documentation: 'Balancer с leastLoad — использует observatory-метрики для выбора наименее загруженного исходящего.',
+    insertText: '{\n  "tag": "balancer-leastload",\n  "selector": [\n    "proxy-"\n  ],\n  "strategy": {\n    "type": "leastLoad",\n    "settings": {\n      "baselines": [\n        "300ms",\n        "500ms"\n      ],\n      "expected": 2\n    }\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:balancer-leastload}",\n  "selector": [\n    "${2:proxy-}"\n  ],\n  "strategy": {\n    "type": "leastLoad",\n    "settings": {\n      "baselines": [\n        "${3:300ms}",\n        "${4:500ms}"\n      ],\n      "expected": ${5:2}\n    }\n  }\n}$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Xray · outbounds (вставка в массив outbounds)
+ * ════════════════════════════════════════════════════════════ */
+
+const XRAY_OUTBOUNDS_SNIPPETS = [
+  {
+    id: 'xray-outbound-direct',
+    label: 'outbound: direct (freedom)',
+    detail: 'Xray · outbounds[]',
+    documentation: 'Прямой исходящий — freedom protocol. Обычный tag: "direct".',
+    insertText: '{\n  "tag": "direct",\n  "protocol": "freedom",\n  "settings": {\n    "domainStrategy": "UseIPv4"\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:direct}",\n  "protocol": "freedom",\n  "settings": {\n    "domainStrategy": "${2|UseIPv4,UseIP,UseIPv6,AsIs|}"\n  }\n}$0',
+  },
+  {
+    id: 'xray-outbound-block',
+    label: 'outbound: block (blackhole)',
+    detail: 'Xray · outbounds[]',
+    documentation: 'Блокирующий исходящий — blackhole protocol. Используется с outboundTag: "block" в rules.',
+    insertText: '{\n  "tag": "block",\n  "protocol": "blackhole",\n  "settings": {\n    "response": {\n      "type": "http"\n    }\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:block}",\n  "protocol": "blackhole",\n  "settings": {\n    "response": {\n      "type": "${2|http,none|}"\n    }\n  }\n}$0',
+  },
+  {
+    id: 'xray-outbound-vless-reality',
+    label: 'outbound: VLESS Reality',
+    detail: 'Xray · outbounds[]',
+    documentation: 'VLESS-исходящий с Reality-транспортом. Подставь реальные address, id, serverName, publicKey, shortId.',
+    insertText: '{\n  "tag": "proxy-reality",\n  "protocol": "vless",\n  "settings": {\n    "vnext": [\n      {\n        "address": "example.com",\n        "port": 443,\n        "users": [\n          {\n            "id": "00000000-0000-0000-0000-000000000000",\n            "encryption": "none",\n            "flow": "xtls-rprx-vision"\n          }\n        ]\n      }\n    ]\n  },\n  "streamSettings": {\n    "network": "tcp",\n    "security": "reality",\n    "realitySettings": {\n      "serverName": "example.com",\n      "fingerprint": "chrome",\n      "publicKey": "",\n      "shortId": ""\n    }\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:proxy-reality}",\n  "protocol": "vless",\n  "settings": {\n    "vnext": [\n      {\n        "address": "${2:example.com}",\n        "port": ${3:443},\n        "users": [\n          {\n            "id": "${4:00000000-0000-0000-0000-000000000000}",\n            "encryption": "none",\n            "flow": "${5|xtls-rprx-vision,|}"\n          }\n        ]\n      }\n    ]\n  },\n  "streamSettings": {\n    "network": "tcp",\n    "security": "reality",\n    "realitySettings": {\n      "serverName": "${6:example.com}",\n      "fingerprint": "${7|chrome,firefox,safari,edge,ios,android,random|}",\n      "publicKey": "${8}",\n      "shortId": "${9}"\n    }\n  }\n}$0',
+  },
+  {
+    id: 'xray-outbound-vless-xhttp',
+    label: 'outbound: VLESS XHTTP',
+    detail: 'Xray · outbounds[]',
+    documentation: 'VLESS-исходящий через XHTTP-транспорт (современный замен ws/grpc в ряде сценариев).',
+    insertText: '{\n  "tag": "proxy-xhttp",\n  "protocol": "vless",\n  "settings": {\n    "vnext": [\n      {\n        "address": "example.com",\n        "port": 443,\n        "users": [\n          {\n            "id": "00000000-0000-0000-0000-000000000000",\n            "encryption": "none"\n          }\n        ]\n      }\n    ]\n  },\n  "streamSettings": {\n    "network": "xhttp",\n    "security": "tls",\n    "tlsSettings": {\n      "serverName": "example.com",\n      "alpn": ["h2"]\n    },\n    "xhttpSettings": {\n      "host": "example.com",\n      "path": "/",\n      "mode": "stream-one"\n    }\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:proxy-xhttp}",\n  "protocol": "vless",\n  "settings": {\n    "vnext": [\n      {\n        "address": "${2:example.com}",\n        "port": ${3:443},\n        "users": [\n          {\n            "id": "${4:00000000-0000-0000-0000-000000000000}",\n            "encryption": "none"\n          }\n        ]\n      }\n    ]\n  },\n  "streamSettings": {\n    "network": "xhttp",\n    "security": "tls",\n    "tlsSettings": {\n      "serverName": "${5:example.com}",\n      "alpn": ["h2"]\n    },\n    "xhttpSettings": {\n      "host": "${6:example.com}",\n      "path": "${7:/}",\n      "mode": "${8|stream-one,packet-up,stream-up|}"\n    }\n  }\n}$0',
+  },
+  {
+    id: 'xray-outbound-trojan',
+    label: 'outbound: Trojan',
+    detail: 'Xray · outbounds[]',
+    documentation: 'Trojan-исходящий через TLS. Простая замена Shadowsocks c TLS-маскировкой.',
+    insertText: '{\n  "tag": "proxy-trojan",\n  "protocol": "trojan",\n  "settings": {\n    "servers": [\n      {\n        "address": "example.com",\n        "port": 443,\n        "password": "your-password"\n      }\n    ]\n  },\n  "streamSettings": {\n    "network": "tcp",\n    "security": "tls",\n    "tlsSettings": {\n      "serverName": "example.com"\n    }\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:proxy-trojan}",\n  "protocol": "trojan",\n  "settings": {\n    "servers": [\n      {\n        "address": "${2:example.com}",\n        "port": ${3:443},\n        "password": "${4:your-password}"\n      }\n    ]\n  },\n  "streamSettings": {\n    "network": "tcp",\n    "security": "tls",\n    "tlsSettings": {\n      "serverName": "${5:example.com}"\n    }\n  }\n}$0',
+  },
+  {
+    id: 'xray-outbound-shadowsocks',
+    label: 'outbound: Shadowsocks',
+    detail: 'Xray · outbounds[]',
+    documentation: 'Shadowsocks-исходящий. Для современных серверов используй 2022-шифры.',
+    insertText: '{\n  "tag": "proxy-ss",\n  "protocol": "shadowsocks",\n  "settings": {\n    "servers": [\n      {\n        "address": "example.com",\n        "port": 8388,\n        "method": "2022-blake3-aes-128-gcm",\n        "password": "your-password"\n      }\n    ]\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:proxy-ss}",\n  "protocol": "shadowsocks",\n  "settings": {\n    "servers": [\n      {\n        "address": "${2:example.com}",\n        "port": ${3:8388},\n        "method": "${4|2022-blake3-aes-128-gcm,2022-blake3-aes-256-gcm,aes-128-gcm,aes-256-gcm,chacha20-poly1305|}",\n        "password": "${5:your-password}"\n      }\n    ]\n  }\n}$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Xray · inbounds (вставка в массив inbounds)
+ * ════════════════════════════════════════════════════════════ */
+
+const XRAY_INBOUNDS_SNIPPETS = [
+  {
+    id: 'xray-inbound-socks',
+    label: 'inbound: socks',
+    detail: 'Xray · inbounds[]',
+    documentation: 'Socks5-входящий без авторизации, слушает локально. udp: true нужен для QUIC/UDP-трафика.',
+    insertText: '{\n  "tag": "socks-in",\n  "listen": "127.0.0.1",\n  "port": 10808,\n  "protocol": "socks",\n  "settings": {\n    "auth": "noauth",\n    "udp": true\n  },\n  "sniffing": {\n    "enabled": true,\n    "destOverride": ["http", "tls", "quic"]\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:socks-in}",\n  "listen": "${2:127.0.0.1}",\n  "port": ${3:10808},\n  "protocol": "socks",\n  "settings": {\n    "auth": "${4|noauth,password|}",\n    "udp": ${5|true,false|}\n  },\n  "sniffing": {\n    "enabled": true,\n    "destOverride": ["http", "tls", "quic"]\n  }\n}$0',
+  },
+  {
+    id: 'xray-inbound-http',
+    label: 'inbound: http',
+    detail: 'Xray · inbounds[]',
+    documentation: 'HTTP-прокси входящий. Полезен для браузеров, не поддерживающих SOCKS5.',
+    insertText: '{\n  "tag": "http-in",\n  "listen": "127.0.0.1",\n  "port": 10809,\n  "protocol": "http",\n  "settings": {\n    "allowTransparent": false\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:http-in}",\n  "listen": "${2:127.0.0.1}",\n  "port": ${3:10809},\n  "protocol": "http",\n  "settings": {\n    "allowTransparent": false\n  }\n}$0',
+  },
+  {
+    id: 'xray-inbound-dokodemo',
+    label: 'inbound: dokodemo-door (transparent)',
+    detail: 'Xray · inbounds[]',
+    documentation: 'Transparent-входящий для iptables REDIRECT / TPROXY. На Keenetic — для перехвата трафика LAN.',
+    insertText: '{\n  "tag": "transparent-in",\n  "listen": "0.0.0.0",\n  "port": 12345,\n  "protocol": "dokodemo-door",\n  "settings": {\n    "network": "tcp,udp",\n    "followRedirect": true\n  },\n  "streamSettings": {\n    "sockopt": {\n      "tproxy": "tproxy"\n    }\n  },\n  "sniffing": {\n    "enabled": true,\n    "destOverride": ["http", "tls", "quic"]\n  }\n}',
+    monacoSnippet: '{\n  "tag": "${1:transparent-in}",\n  "listen": "${2:0.0.0.0}",\n  "port": ${3:12345},\n  "protocol": "dokodemo-door",\n  "settings": {\n    "network": "tcp,udp",\n    "followRedirect": true\n  },\n  "streamSettings": {\n    "sockopt": {\n      "tproxy": "${4|tproxy,redirect,off|}"\n    }\n  },\n  "sniffing": {\n    "enabled": true,\n    "destOverride": ["http", "tls", "quic"]\n  }\n}$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Xray · streamSettings (вставка внутри streamSettings объекта)
+ * ════════════════════════════════════════════════════════════ */
+
+const XRAY_STREAM_SETTINGS_SNIPPETS = [
+  {
+    id: 'xray-stream-ws',
+    label: 'streamSettings: WebSocket',
+    detail: 'Xray · streamSettings',
+    documentation: 'WebSocket-транспорт для VLESS/VMess/Trojan. Часто используется за CDN.',
+    insertText: '"network": "ws",\n"wsSettings": {\n  "path": "/",\n  "headers": {\n    "Host": "example.com"\n  }\n}',
+    monacoSnippet: '"network": "ws",\n"wsSettings": {\n  "path": "${1:/}",\n  "headers": {\n    "Host": "${2:example.com}"\n  }\n}$0',
+  },
+  {
+    id: 'xray-stream-grpc',
+    label: 'streamSettings: gRPC',
+    detail: 'Xray · streamSettings',
+    documentation: 'gRPC-транспорт. Требует TLS и совпадающий serviceName на клиенте/сервере.',
+    insertText: '"network": "grpc",\n"grpcSettings": {\n  "serviceName": "xray-svc",\n  "multiMode": false\n}',
+    monacoSnippet: '"network": "grpc",\n"grpcSettings": {\n  "serviceName": "${1:xray-svc}",\n  "multiMode": ${2|false,true|}\n}$0',
+  },
+  {
+    id: 'xray-stream-xhttp',
+    label: 'streamSettings: XHTTP',
+    detail: 'Xray · streamSettings',
+    documentation: 'XHTTP-транспорт (новое поколение). Mode stream-one обычно ок для browser-traffic, packet-up — для UDP-like нагрузок.',
+    insertText: '"network": "xhttp",\n"xhttpSettings": {\n  "host": "example.com",\n  "path": "/",\n  "mode": "stream-one"\n}',
+    monacoSnippet: '"network": "xhttp",\n"xhttpSettings": {\n  "host": "${1:example.com}",\n  "path": "${2:/}",\n  "mode": "${3|stream-one,packet-up,stream-up|}"\n}$0',
+  },
+  {
+    id: 'xray-stream-tcp-http',
+    label: 'streamSettings: TCP+HTTP obfuscation',
+    detail: 'Xray · streamSettings',
+    documentation: 'Raw TCP с HTTP-заголовками для обхода DPI. Устаревает в пользу XHTTP, но ещё встречается.',
+    insertText: '"network": "tcp",\n"tcpSettings": {\n  "header": {\n    "type": "http",\n    "request": {\n      "path": ["/"],\n      "headers": {\n        "Host": ["example.com"]\n      }\n    }\n  }\n}',
+    monacoSnippet: '"network": "tcp",\n"tcpSettings": {\n  "header": {\n    "type": "http",\n    "request": {\n      "path": ["${1:/}"],\n      "headers": {\n        "Host": ["${2:example.com}"]\n      }\n    }\n  }\n}$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Xray · config top-level (dns, observatory)
+ * ════════════════════════════════════════════════════════════ */
+
+const XRAY_CONFIG_TOP_LEVEL_SNIPPETS = [
+  {
+    id: 'xray-config-dns',
+    label: 'dns block (Keenetic — по инструкции)',
+    detail: 'Xray · config.dns',
+    documentation: 'DNS-блок Xray для DNS-over-VLESS сценария. На Keenetic обычно используется вместе с dns-out outbound, routing rules для port 53/dns-in и domainStrategy на proxy/direct.',
+    warning: KEENETIC_XRAY_DNS_NOTE,
+    insertText: '"dns": {\n  "tag": "dns-in",\n  "servers": [\n    "8.8.8.8"\n  ],\n  "queryStrategy": "UseIP"\n}',
+    monacoSnippet: '"dns": {\n  "tag": "${1:dns-in}",\n  "servers": [\n    "${2:8.8.8.8}"\n  ],\n  "queryStrategy": "${3|UseIP,UseIPv4,UseIPv6|}"\n}$0',
+  },
+  {
+    id: 'xray-config-observatory',
+    label: 'observatory block',
+    detail: 'Xray · config.observatory',
+    documentation: 'Observatory — фоновое тестирование outbounds для balancer leastPing/leastLoad. Осторожно с числом subjectSelector — чем больше outbounds, тем выше нагрузка на роутер.',
+    insertText: '"observatory": {\n  "subjectSelector": [\n    "proxy-"\n  ],\n  "probeUrl": "http://www.gstatic.com/generate_204",\n  "probeInterval": "5m"\n}',
+    monacoSnippet: '"observatory": {\n  "subjectSelector": [\n    "${1:proxy-}"\n  ],\n  "probeUrl": "${2:http://www.gstatic.com/generate_204}",\n  "probeInterval": "${3:5m}"\n}$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Mihomo · proxies (вставка в массив proxies)
+ * ════════════════════════════════════════════════════════════ */
+
+const MIHOMO_PROXIES_SNIPPETS = [
+  {
+    id: 'mihomo-proxy-vless',
+    label: 'proxy: vless',
+    detail: 'Mihomo · proxies[]',
+    documentation: 'VLESS-прокси через TLS. flow xtls-rprx-vision совместим с Xray Reality.',
+    insertText: 'name: "vless-proxy"\ntype: vless\nserver: example.com\nport: 443\nuuid: "00000000-0000-0000-0000-000000000000"\nnetwork: tcp\ntls: true\nservername: example.com\nflow: xtls-rprx-vision\nudp: true',
+    monacoSnippet: 'name: "${1:vless-proxy}"\ntype: vless\nserver: ${2:example.com}\nport: ${3:443}\nuuid: "${4:00000000-0000-0000-0000-000000000000}"\nnetwork: ${5|tcp,ws,grpc|}\ntls: true\nservername: ${6:example.com}\nflow: ${7|xtls-rprx-vision,|}\nudp: true$0',
+  },
+  {
+    id: 'mihomo-proxy-vmess',
+    label: 'proxy: vmess',
+    detail: 'Mihomo · proxies[]',
+    documentation: 'VMess-прокси. Часто используется с ws+tls за CDN.',
+    insertText: 'name: "vmess-proxy"\ntype: vmess\nserver: example.com\nport: 443\nuuid: "00000000-0000-0000-0000-000000000000"\nalterId: 0\ncipher: auto\nnetwork: ws\ntls: true\nservername: example.com\nws-opts:\n  path: /\n  headers:\n    Host: example.com\nudp: true',
+    monacoSnippet: 'name: "${1:vmess-proxy}"\ntype: vmess\nserver: ${2:example.com}\nport: ${3:443}\nuuid: "${4:00000000-0000-0000-0000-000000000000}"\nalterId: ${5:0}\ncipher: ${6|auto,aes-128-gcm,chacha20-poly1305,none|}\nnetwork: ws\ntls: true\nservername: ${7:example.com}\nws-opts:\n  path: ${8:/}\n  headers:\n    Host: ${9:example.com}\nudp: true$0',
+  },
+  {
+    id: 'mihomo-proxy-trojan',
+    label: 'proxy: trojan',
+    detail: 'Mihomo · proxies[]',
+    documentation: 'Trojan-прокси через TLS. Минимальные поля — server/port/password/sni.',
+    insertText: 'name: "trojan-proxy"\ntype: trojan\nserver: example.com\nport: 443\npassword: "your-password"\nsni: example.com\nudp: true',
+    monacoSnippet: 'name: "${1:trojan-proxy}"\ntype: trojan\nserver: ${2:example.com}\nport: ${3:443}\npassword: "${4:your-password}"\nsni: ${5:example.com}\nudp: true$0',
+  },
+  {
+    id: 'mihomo-proxy-ss',
+    label: 'proxy: shadowsocks',
+    detail: 'Mihomo · proxies[]',
+    documentation: 'Shadowsocks-прокси. Поддерживает 2022-шифры и AEAD.',
+    insertText: 'name: "ss-proxy"\ntype: ss\nserver: example.com\nport: 8388\ncipher: 2022-blake3-aes-128-gcm\npassword: "your-password"\nudp: true',
+    monacoSnippet: 'name: "${1:ss-proxy}"\ntype: ss\nserver: ${2:example.com}\nport: ${3:8388}\ncipher: ${4|2022-blake3-aes-128-gcm,2022-blake3-aes-256-gcm,aes-128-gcm,aes-256-gcm,chacha20-ietf-poly1305|}\npassword: "${5:your-password}"\nudp: true$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Mihomo · proxy-groups
+ * ════════════════════════════════════════════════════════════ */
+
+const MIHOMO_PROXY_GROUPS_SNIPPETS = [
+  {
+    id: 'mihomo-group-select',
+    label: 'proxy-group: select',
+    detail: 'Mihomo · proxy-groups[]',
+    documentation: 'Ручной выбор — пользователь выбирает активный прокси в UI.',
+    insertText: 'name: "select-manual"\ntype: select\nproxies:\n  - "vless-proxy"\n  - "trojan-proxy"\n  - "DIRECT"',
+    monacoSnippet: 'name: "${1:select-manual}"\ntype: select\nproxies:\n  - "${2:vless-proxy}"\n  - "${3:trojan-proxy}"\n  - "${4:DIRECT}"$0',
+  },
+  {
+    id: 'mihomo-group-url-test',
+    label: 'proxy-group: url-test',
+    detail: 'Mihomo · proxy-groups[]',
+    documentation: 'Автовыбор самого быстрого прокси по ping URL. На Keenetic interval >= 300 — 300+ прокси нагружают роутер.',
+    insertText: 'name: "auto"\ntype: url-test\nproxies:\n  - "vless-proxy"\n  - "trojan-proxy"\nurl: "http://www.gstatic.com/generate_204"\ninterval: 300\ntolerance: 50',
+    monacoSnippet: 'name: "${1:auto}"\ntype: url-test\nproxies:\n  - "${2:vless-proxy}"\n  - "${3:trojan-proxy}"\nurl: "${4:http://www.gstatic.com/generate_204}"\ninterval: ${5:300}\ntolerance: ${6:50}$0',
+  },
+  {
+    id: 'mihomo-group-fallback',
+    label: 'proxy-group: fallback',
+    detail: 'Mihomo · proxy-groups[]',
+    documentation: 'Переключается на следующий прокси, если предыдущий недоступен.',
+    insertText: 'name: "fallback"\ntype: fallback\nproxies:\n  - "vless-proxy"\n  - "trojan-proxy"\n  - "ss-proxy"\nurl: "http://www.gstatic.com/generate_204"\ninterval: 300',
+    monacoSnippet: 'name: "${1:fallback}"\ntype: fallback\nproxies:\n  - "${2:vless-proxy}"\n  - "${3:trojan-proxy}"\n  - "${4:ss-proxy}"\nurl: "${5:http://www.gstatic.com/generate_204}"\ninterval: ${6:300}$0',
+  },
+  {
+    id: 'mihomo-group-load-balance',
+    label: 'proxy-group: load-balance',
+    detail: 'Mihomo · proxy-groups[]',
+    documentation: 'Распределяет соединения по прокси. Стратегия round-robin или consistent-hashing.',
+    insertText: 'name: "load-balance"\ntype: load-balance\nproxies:\n  - "vless-proxy"\n  - "trojan-proxy"\nurl: "http://www.gstatic.com/generate_204"\ninterval: 300\nstrategy: round-robin',
+    monacoSnippet: 'name: "${1:load-balance}"\ntype: load-balance\nproxies:\n  - "${2:vless-proxy}"\n  - "${3:trojan-proxy}"\nurl: "${4:http://www.gstatic.com/generate_204}"\ninterval: ${5:300}\nstrategy: ${6|round-robin,consistent-hashing,sticky-sessions|}$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Mihomo · proxy-providers / rule-providers
+ * ════════════════════════════════════════════════════════════ */
+
+const MIHOMO_PROXY_PROVIDERS_SNIPPETS = [
+  {
+    id: 'mihomo-proxy-provider-http',
+    label: 'proxy-provider: http (subscription)',
+    detail: 'Mihomo · proxy-providers',
+    documentation: 'Provider подписки. health-check.interval = 300+ рекомендуется, чтобы не перегружать роутер.',
+    insertText: 'subscription:\n  type: http\n  url: "https://example.com/subscription"\n  interval: 86400\n  path: ./providers/subscription.yaml\n  health-check:\n    enable: true\n    interval: 300\n    url: "http://www.gstatic.com/generate_204"',
+    monacoSnippet: '${1:subscription}:\n  type: http\n  url: "${2:https://example.com/subscription}"\n  interval: ${3:86400}\n  path: ${4:./providers/subscription.yaml}\n  health-check:\n    enable: true\n    interval: ${5:300}\n    url: "${6:http://www.gstatic.com/generate_204}"$0',
+  },
+];
+
+const MIHOMO_RULE_PROVIDERS_SNIPPETS = [
+  {
+    id: 'mihomo-rule-provider-domain',
+    label: 'rule-provider: domain list',
+    detail: 'Mihomo · rule-providers',
+    documentation: 'Provider списка доменов (rule type: domain).',
+    insertText: 'ads-list:\n  type: http\n  behavior: domain\n  url: "https://example.com/ads.yaml"\n  interval: 86400\n  path: ./rules/ads-list.yaml\n  format: yaml',
+    monacoSnippet: '${1:ads-list}:\n  type: http\n  behavior: ${2|domain,ipcidr,classical|}\n  url: "${3:https://example.com/ads.yaml}"\n  interval: ${4:86400}\n  path: ${5:./rules/ads-list.yaml}\n  format: ${6|yaml,text,mrs|}$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Mihomo · top-level (dns, tun, sniffer)
+ * ════════════════════════════════════════════════════════════ */
+
+const MIHOMO_TOP_LEVEL_SNIPPETS = [
+  {
+    id: 'mihomo-dns-block',
+    label: 'dns block (Keenetic — обычно не нужен)',
+    detail: 'Mihomo · dns',
+    documentation: 'DNS-блок Mihomo. Настраивает nameserver, fake-ip и fallback. Обычно нужен только если активно используется TUN/transparent-режим.',
+    warning: KEENETIC_MIHOMO_DNS_NOTE,
+    insertText: 'dns:\n  enable: true\n  ipv6: false\n  enhanced-mode: fake-ip\n  fake-ip-range: 198.18.0.1/16\n  fake-ip-filter:\n    - "*.lan"\n    - "localhost.ptlogin2.qq.com"\n  nameserver:\n    - https://1.1.1.1/dns-query\n    - https://dns.google/dns-query\n  fallback:\n    - tls://8.8.4.4:853\n  fallback-filter:\n    geoip: true\n    geoip-code: RU',
+    monacoSnippet: 'dns:\n  enable: true\n  ipv6: ${1|false,true|}\n  enhanced-mode: ${2|fake-ip,redir-host|}\n  fake-ip-range: ${3:198.18.0.1/16}\n  fake-ip-filter:\n    - "*.lan"\n    - "localhost.ptlogin2.qq.com"\n  nameserver:\n    - ${4:https://1.1.1.1/dns-query}\n    - ${5:https://dns.google/dns-query}\n  fallback:\n    - ${6:tls://8.8.4.4:853}\n  fallback-filter:\n    geoip: true\n    geoip-code: ${7:RU}$0',
+  },
+  {
+    id: 'mihomo-tun-block',
+    label: 'tun block (Keenetic — обычно не нужен)',
+    detail: 'Mihomo · tun',
+    documentation: 'TUN-блок Mihomo. Включает виртуальный сетевой интерфейс для transparent-проксирования.',
+    warning: KEENETIC_MIHOMO_TUN_NOTE,
+    insertText: 'tun:\n  enable: true\n  stack: system\n  auto-route: true\n  auto-detect-interface: true\n  dns-hijack:\n    - any:53\n    - tcp://any:53\n  mtu: 9000\n  strict-route: true',
+    monacoSnippet: 'tun:\n  enable: ${1|true,false|}\n  stack: ${2|system,gvisor,mixed|}\n  auto-route: true\n  auto-detect-interface: true\n  dns-hijack:\n    - any:53\n    - tcp://any:53\n  mtu: ${3:9000}\n  strict-route: ${4|true,false|}$0',
+  },
+  {
+    id: 'mihomo-sniffer-block',
+    label: 'sniffer block',
+    detail: 'Mihomo · sniffer',
+    documentation: 'Sniffer — восстанавливает host/SNI из пакетов для правильного матчинга в rules. На Keenetic безопасен и рекомендуется.',
+    insertText: 'sniffer:\n  enable: true\n  sniff:\n    HTTP:\n      ports: [80, 8080-8880]\n      override-destination: true\n    TLS:\n      ports: [443, 8443]\n    QUIC:\n      ports: [443, 8443]\n  force-domain:\n    - "+.v2ex.com"\n  skip-domain:\n    - "Mijia Cloud"',
+    monacoSnippet: 'sniffer:\n  enable: true\n  sniff:\n    HTTP:\n      ports: [80, 8080-8880]\n      override-destination: ${1|true,false|}\n    TLS:\n      ports: [443, 8443]\n    QUIC:\n      ports: [443, 8443]\n  force-domain:\n    - "${2:+.v2ex.com}"\n  skip-domain:\n    - "${3:Mijia Cloud}"$0',
+  },
+];
+
+/* ════════════════════════════════════════════════════════════
+ *  Matching helpers
+ * ════════════════════════════════════════════════════════════ */
+
+function normalizePointer(pointer) {
+  if (pointer == null) return '';
+  let value = String(pointer);
+  if (!value) return '';
+  if (value.charAt(0) !== '/') value = `/${value}`;
+  return value;
+}
+
+function normalizePath(path) {
+  if (!Array.isArray(path)) return [];
+  return path.map((item) => (typeof item === 'number' ? `[${item}]` : String(item || '')));
+}
+
+function pathToPointer(path) {
+  const parts = normalizePath(path).map((item) => {
+    if (item.startsWith('[') && item.endsWith(']')) return item.slice(1, -1);
+    return item.replace(/~/g, '~0').replace(/\//g, '~1');
+  });
+  return parts.length ? `/${parts.join('/')}` : '';
+}
+
+function isNumericSegment(segment) {
+  if (segment == null) return false;
+  return /^\d+$/.test(String(segment));
+}
+
+function matchesXrayRoutingRulesPointer(pointer) {
+  const normalized = normalizePointer(pointer);
+  if (!normalized) return false;
+  if (/^\/rules(\/\d+)?$/.test(normalized)) return true;
+  if (/^\/routing\/rules(\/\d+)?$/.test(normalized)) return true;
+  return false;
+}
+
+function matchesXrayRoutingBalancersPointer(pointer) {
+  const normalized = normalizePointer(pointer);
+  if (!normalized) return false;
+  if (/^\/balancers(\/\d+)?$/.test(normalized)) return true;
+  if (/^\/routing\/balancers(\/\d+)?$/.test(normalized)) return true;
+  return false;
+}
+
+function matchesXrayOutboundsArrayPointer(pointer) {
+  const normalized = normalizePointer(pointer);
+  if (!normalized) return false;
+  return /^\/outbounds(\/\d+)?$/.test(normalized);
+}
+
+function matchesXrayInboundsArrayPointer(pointer) {
+  const normalized = normalizePointer(pointer);
+  if (!normalized) return false;
+  return /^\/inbounds(\/\d+)?$/.test(normalized);
+}
+
+function matchesXrayStreamSettingsPointer(pointer) {
+  const normalized = normalizePointer(pointer);
+  if (!normalized) return false;
+  return /\/streamSettings$/.test(normalized);
+}
+
+function matchesXrayConfigRootPointer(pointer) {
+  const normalized = normalizePointer(pointer);
+  return normalized === '' || normalized === '/';
+}
+
+function matchesMihomoRootPath(path) {
+  const normalized = normalizePath(path);
+  return normalized.length === 0;
+}
+
+function matchesMihomoProxiesArrayPath(path) {
+  const normalized = normalizePath(path);
+  if (!normalized.length) return false;
+  if (normalized[0] !== 'proxies') return false;
+  if (normalized.length === 1) return true;
+  return normalized.length === 2 && isNumericSegment(normalized[1]);
+}
+
+function matchesMihomoProxyGroupsArrayPath(path) {
+  const normalized = normalizePath(path);
+  if (!normalized.length) return false;
+  if (normalized[0] !== 'proxy-groups') return false;
+  if (normalized.length === 1) return true;
+  return normalized.length === 2 && isNumericSegment(normalized[1]);
+}
+
+function matchesMihomoProxyProvidersPath(path) {
+  const normalized = normalizePath(path);
+  if (!normalized.length) return false;
+  return normalized[0] === 'proxy-providers';
+}
+
+function matchesMihomoRuleProvidersPath(path) {
+  const normalized = normalizePath(path);
+  if (!normalized.length) return false;
+  return normalized[0] === 'rule-providers';
+}
+
+/* ════════════════════════════════════════════════════════════
+ *  Public API — Xray
+ * ════════════════════════════════════════════════════════════ */
+
+function normalizeXraySchemaKind(value) {
+  const raw = String(value || '').toLowerCase();
+  if (!raw) return '';
+  if (raw.includes('routing')) return 'xray-routing';
+  if (raw.includes('outbound')) return 'xray-outbounds';
+  if (raw.includes('inbound')) return 'xray-inbounds';
+  if (raw.includes('config')) return 'xray-config';
+  if (raw === 'xray') return 'xray-config';
+  return raw;
+}
+
+export function getXraySnippets(params) {
+  const input = params && typeof params === 'object' ? params : {};
+  const schemaKind = normalizeXraySchemaKind(input.schemaKind);
+  const pointer = normalizePointer(input.pointer);
+  const list = [];
+
+  if (schemaKind === 'xray-routing' || schemaKind === 'xray-config') {
+    if (matchesXrayRoutingRulesPointer(pointer)) list.push(...XRAY_ROUTING_RULES_SNIPPETS);
+    if (matchesXrayRoutingBalancersPointer(pointer)) list.push(...XRAY_ROUTING_BALANCERS_SNIPPETS);
+  }
+  if (schemaKind === 'xray-outbounds') {
+    if (matchesXrayOutboundsArrayPointer(pointer) || pointer === '' || pointer === '/') {
+      list.push(...XRAY_OUTBOUNDS_SNIPPETS);
+    }
+    if (matchesXrayStreamSettingsPointer(pointer)) list.push(...XRAY_STREAM_SETTINGS_SNIPPETS);
+  }
+  if (schemaKind === 'xray-inbounds') {
+    if (matchesXrayInboundsArrayPointer(pointer) || pointer === '' || pointer === '/') {
+      list.push(...XRAY_INBOUNDS_SNIPPETS);
+    }
+    if (matchesXrayStreamSettingsPointer(pointer)) list.push(...XRAY_STREAM_SETTINGS_SNIPPETS);
+  }
+  if (schemaKind === 'xray-config') {
+    if (matchesXrayOutboundsArrayPointer(pointer)) list.push(...XRAY_OUTBOUNDS_SNIPPETS);
+    if (matchesXrayInboundsArrayPointer(pointer)) list.push(...XRAY_INBOUNDS_SNIPPETS);
+    if (matchesXrayStreamSettingsPointer(pointer)) list.push(...XRAY_STREAM_SETTINGS_SNIPPETS);
+    if (matchesXrayConfigRootPointer(pointer)) list.push(...XRAY_CONFIG_TOP_LEVEL_SNIPPETS);
+  }
+
+  return list.map(cloneSnippet);
+}
+
+/* ════════════════════════════════════════════════════════════
+ *  Public API — Mihomo
+ * ════════════════════════════════════════════════════════════ */
+
+export function getMihomoSnippets(params) {
+  const input = params && typeof params === 'object' ? params : {};
+  const path = normalizePath(input.path);
+  const list = [];
+
+  if (matchesMihomoRootPath(path)) {
+    list.push(...MIHOMO_TOP_LEVEL_SNIPPETS);
+  }
+  if (matchesMihomoProxiesArrayPath(path)) {
+    list.push(...MIHOMO_PROXIES_SNIPPETS);
+  }
+  if (matchesMihomoProxyGroupsArrayPath(path)) {
+    list.push(...MIHOMO_PROXY_GROUPS_SNIPPETS);
+  }
+  if (matchesMihomoProxyProvidersPath(path)) {
+    list.push(...MIHOMO_PROXY_PROVIDERS_SNIPPETS);
+  }
+  if (matchesMihomoRuleProvidersPath(path)) {
+    list.push(...MIHOMO_RULE_PROVIDERS_SNIPPETS);
+  }
+
+  return list.map(cloneSnippet);
+}
+
+/* ════════════════════════════════════════════════════════════
+ *  Snippet provider factories — используются редакторами
+ * ════════════════════════════════════════════════════════════ */
+
+export function createXraySnippetProvider(schemaKind) {
+  const kind = normalizeXraySchemaKind(schemaKind);
+  return function xraySnippetProvider(ctx) {
+    const context = ctx && typeof ctx === 'object' ? ctx : {};
+    return getXraySnippets({
+      schemaKind: context.schemaKind || kind,
+      pointer: context.pointer || '',
+    });
+  };
+}
+
+export function createMihomoSnippetProvider() {
+  return function mihomoSnippetProvider(ctx) {
+    const context = ctx && typeof ctx === 'object' ? ctx : {};
+    return getMihomoSnippets({ path: context.path || [] });
+  };
+}
+
+function cloneSnippet(snippet) {
+  if (!snippet || typeof snippet !== 'object') return snippet;
+  return {
+    id: String(snippet.id || ''),
+    label: String(snippet.label || ''),
+    kind: 'snippet',
+    detail: String(snippet.detail || ''),
+    documentation: String(snippet.documentation || ''),
+    warning: snippet.warning ? String(snippet.warning) : null,
+    insertText: String(snippet.insertText || ''),
+    monacoSnippet: String(snippet.monacoSnippet || snippet.insertText || ''),
+  };
+}
+
+/* ════════════════════════════════════════════════════════════
+ *  Helpers for editor runtimes
+ * ════════════════════════════════════════════════════════════ */
+
+export function renderSnippetDocumentation(snippet) {
+  if (!snippet || typeof snippet !== 'object') return '';
+  const parts = [];
+  if (snippet.documentation) parts.push(String(snippet.documentation));
+  if (snippet.warning) parts.push(`⚠ ${String(snippet.warning)}`);
+  return parts.join('\n\n');
+}
+
+export function snippetsToCompletionOptions(snippets, options = {}) {
+  const list = Array.isArray(snippets) ? snippets : [];
+  const mode = options && options.mode === 'monaco' ? 'monaco' : 'cm6';
+  return list
+    .filter((item) => item && typeof item === 'object' && item.label && (item.insertText || item.monacoSnippet))
+    .map((item) => ({
+      id: item.id,
+      label: item.label,
+      type: 'snippet',
+      detail: item.detail || '',
+      insertText: mode === 'monaco' ? (item.monacoSnippet || item.insertText) : item.insertText,
+      useSnippetSyntax: mode === 'monaco',
+      documentation: renderSnippetDocumentation(item),
+      warning: item.warning || null,
+    }));
+}
+
+export const schemaSnippetsApi = Object.freeze({
+  getXraySnippets,
+  getMihomoSnippets,
+  createXraySnippetProvider,
+  createMihomoSnippetProvider,
+  renderSnippetDocumentation,
+  snippetsToCompletionOptions,
+});

--- a/xkeen-ui/static/js/ui/yaml_schema.js
+++ b/xkeen-ui/static/js/ui/yaml_schema.js
@@ -1,4 +1,5 @@
 import { load as loadYaml } from 'js-yaml';
+import { validateMihomoConfigSemantics } from './schema_semantic_validation.js';
 
 function asString(value) {
   return value == null ? '' : String(value);
@@ -577,7 +578,9 @@ export function validateYamlTextAgainstSchema(text, schema, options = {}) {
     rootSchema: schema || {},
     maxErrors: Math.max(1, Number(options.maxErrors || 40)),
   };
-  const errors = validateNode(parsed, schema, ctx, []);
+  const schemaErrors = validateNode(parsed, schema, ctx, []);
+  const semanticErrors = validateMihomoConfigSemantics(parsed, options);
+  const errors = schemaErrors.concat(Array.isArray(semanticErrors) ? semanticErrors : []);
   const diagnostics = errors.map((item) => makeDiagnostic(index, item)).slice(0, ctx.maxErrors);
   const first = diagnostics[0] || null;
   return {

--- a/xkeen-ui/static/js/ui/yaml_schema.js
+++ b/xkeen-ui/static/js/ui/yaml_schema.js
@@ -1126,6 +1126,38 @@ function parseYamlBestEffort(text) {
   return undefined;
 }
 
+function resolveYamlSnippetProvider(options) {
+  if (!options || typeof options !== 'object') return null;
+  const provider = options.snippetProvider;
+  if (typeof provider === 'function') return provider;
+  if (provider && typeof provider.getSnippets === 'function') {
+    return (ctx) => provider.getSnippets(ctx);
+  }
+  return null;
+}
+
+function buildYamlSnippetCompletionOptions(snippets) {
+  const list = Array.isArray(snippets) ? snippets : [];
+  return list
+    .filter((item) => item && item.label && (item.insertText || item.monacoSnippet))
+    .map((item) => {
+      const plainParts = [];
+      if (item.documentation) plainParts.push(String(item.documentation));
+      if (item.warning) plainParts.push(`⚠ ${String(item.warning)}`);
+      const plain = plainParts.join('\n\n') || '';
+      const insertPlain = String(item.insertText || item.monacoSnippet || '');
+      const insertSnippet = String(item.monacoSnippet || item.insertText || '');
+      return {
+        label: `📦 ${String(item.label)}`,
+        type: 'snippet',
+        insertText: insertPlain,
+        monacoSnippet: insertSnippet,
+        detail: String(item.detail || 'snippet'),
+        documentation: plain ? { plain, markdown: plain } : {},
+      };
+    });
+}
+
 export function completeYamlTextFromSchema(text, schema, options = {}) {
   const source = asString(text);
   const rootSchema = schema || {};
@@ -1146,6 +1178,24 @@ export function completeYamlTextFromSchema(text, schema, options = {}) {
     list = buildKeyCompletionOptions(targetSchema, rootSchema, context.prefix, context);
   } else if (context.kind === 'value') {
     list = buildValueCompletionOptions(targetSchema, rootSchema, context.prefix);
+  }
+
+  const provider = resolveYamlSnippetProvider(options);
+  let snippetOptions = [];
+  if (provider) {
+    let snippets = null;
+    try {
+      snippets = provider({
+        path: Array.isArray(context.path) ? context.path.slice() : [],
+        kind: context.kind || '',
+        prefix: context.prefix || '',
+        offset: options.offset,
+      });
+    } catch (e) {
+      snippets = null;
+    }
+    snippetOptions = buildYamlSnippetCompletionOptions(snippets);
+    if (snippetOptions.length) list = list.concat(snippetOptions);
   }
 
   if (!list.length) return null;

--- a/xkeen-ui/static/js/vendor/codemirror_json_schema.js
+++ b/xkeen-ui/static/js/vendor/codemirror_json_schema.js
@@ -1543,6 +1543,76 @@ function fallbackValueCompletion(ctx, schema) {
   });
 }
 
+function resolveSnippetProvider(options) {
+  if (!options || typeof options !== 'object') return null;
+  const provider = options.snippetProvider;
+  if (typeof provider === 'function') return provider;
+  if (provider && typeof provider.getSnippets === 'function') {
+    return (ctx) => provider.getSnippets(ctx);
+  }
+  return null;
+}
+
+function buildSnippetCompletionOptions(snippets) {
+  const list = Array.isArray(snippets) ? snippets : [];
+  return list
+    .filter((item) => item && item.label && item.insertText)
+    .map((item) => {
+      const info = [];
+      if (item.documentation) info.push(String(item.documentation));
+      if (item.warning) info.push(`⚠ ${String(item.warning)}`);
+      return {
+        label: `📦 ${String(item.label)}`,
+        type: 'snippet',
+        detail: String(item.detail || 'snippet'),
+        info: info.join('\n\n') || undefined,
+        apply: String(item.insertText),
+        boost: -5,
+      };
+    });
+}
+
+function mergeSnippetCompletions(result, snippetOptions) {
+  if (!snippetOptions || !snippetOptions.length) return result;
+  if (!result) {
+    return null;
+  }
+  const mergedOptions = Array.isArray(result.options) ? result.options.concat(snippetOptions) : snippetOptions.slice();
+  return { ...result, options: mergedOptions };
+}
+
+function resolveSnippetPointerFromContext(ctx, node) {
+  try {
+    const doc = ctx.state.doc;
+    let current = node || null;
+    while (current) {
+      if (current.name === 'Object' || current.name === 'Array') {
+        return getJsonPointerAt(doc, current) || '';
+      }
+      current = current.parent;
+    }
+  } catch (e) {}
+  return '';
+}
+
+function collectSnippetOptionsFor(ctx, options, fallbackPointer) {
+  const provider = resolveSnippetProvider(options);
+  if (!provider) return [];
+  let snippets = null;
+  try {
+    snippets = provider({
+      pointer: fallbackPointer || '',
+      schemaKind: options && options.schemaKind ? options.schemaKind : '',
+      state: ctx.state,
+      pos: ctx.pos,
+      explicit: !!ctx.explicit,
+    });
+  } catch (e) {
+    snippets = null;
+  }
+  return buildSnippetCompletionOptions(snippets);
+}
+
 function jsonCompletion(options) {
   return function jsonDoCompletion(ctx) {
     const schema = getJSONSchema(ctx.state);
@@ -1552,12 +1622,17 @@ function jsonCompletion(options) {
     const node = tree.resolveInner(ctx.pos, -1);
     const doc = ctx.state.doc;
     const nodeIsError = !!(node && node.type && node.type.isError);
+    const snippetPointer = resolveSnippetPointerFromContext(ctx, node);
+    const snippetOptions = collectSnippetOptionsFor(ctx, options, snippetPointer);
 
     if (nodeIsError) {
       const earlyValueCompletion = fallbackValueCompletion(ctx, schema);
-      if (earlyValueCompletion) return earlyValueCompletion;
+      if (earlyValueCompletion) return mergeSnippetCompletions(earlyValueCompletion, snippetOptions);
       const earlyPropertyCompletion = fallbackPropertyCompletion(ctx, schema);
-      if (earlyPropertyCompletion) return earlyPropertyCompletion;
+      if (earlyPropertyCompletion) return mergeSnippetCompletions(earlyPropertyCompletion, snippetOptions);
+      if (snippetOptions.length && ctx.explicit) {
+        return { from: ctx.pos, to: ctx.pos, options: snippetOptions, filter: false };
+      }
     }
 
     // Determine if we're in a property name or value context
@@ -1611,7 +1686,14 @@ function jsonCompletion(options) {
       }
     }
 
-    if (!isPropertyName && !isValue) return fallbackPropertyCompletion(ctx, schema) || fallbackValueCompletion(ctx, schema);
+    if (!isPropertyName && !isValue) {
+      const genericResult = fallbackPropertyCompletion(ctx, schema) || fallbackValueCompletion(ctx, schema);
+      if (genericResult) return mergeSnippetCompletions(genericResult, snippetOptions);
+      if (snippetOptions.length && ctx.explicit) {
+        return { from: ctx.pos, to: ctx.pos, options: snippetOptions, filter: false };
+      }
+      return null;
+    }
 
     // Find the JSON pointer to the parent object
     const pointer = parentObjectNode ? getJsonPointerAt(doc, parentObjectNode) : '';
@@ -1644,13 +1726,13 @@ function jsonCompletion(options) {
 
       const afterNode = node.name === 'PropertyName' ? node.nextSibling : null;
       const hasColon = afterNode && doc.sliceString(afterNode.from, afterNode.from + 1) === ':';
-      return propertyCompletionResult(schema, parentSchema, {
+      return mergeSnippetCompletions(propertyCompletionResult(schema, parentSchema, {
         from,
         to,
         prefix,
         existingKeys,
         hasColon,
-      });
+      }), snippetOptions);
     }
 
     // --- Value completions ---
@@ -1667,9 +1749,12 @@ function jsonCompletion(options) {
       let to = node.to;
       const rawBeforeCursor = doc.sliceString(node.from, Math.min(ctx.pos, node.to));
       const prefix = rawBeforeCursor.replace(/^["']/, '');
-      return valueCompletionResult(schema, propSchema, { from, to, prefix });
+      return mergeSnippetCompletions(valueCompletionResult(schema, propSchema, { from, to, prefix }), snippetOptions);
     }
 
+    if (snippetOptions.length && ctx.explicit) {
+      return { from: ctx.pos, to: ctx.pos, options: snippetOptions, filter: false };
+    }
     return null;
   };
 }

--- a/xkeen-ui/static/js/vendor/codemirror_json_schema.js
+++ b/xkeen-ui/static/js/vendor/codemirror_json_schema.js
@@ -21,6 +21,7 @@ import { StateEffect, StateField } from '@codemirror/state';
 import { hoverTooltip } from '@codemirror/view';
 import { syntaxTree } from '@codemirror/language';
 import { parse as parseJsonc, parseTree as parseJsoncTree } from 'jsonc-parser';
+import { validateXrayRoutingSemantics } from '../ui/schema_semantic_validation.js';
 
 /* ════════════════════════════════════════════════════════════
  *  1. Schema StateField — stores the current JSON Schema
@@ -620,6 +621,32 @@ function withDiagnosticContext(message, pointer, doc, mapping) {
   return `${message} (${parts.join('; ')})`;
 }
 
+function normalizeSemanticDiagnostics(list) {
+  if (!Array.isArray(list)) return [];
+  return list.filter((item) => item && typeof item === 'object' && item.message);
+}
+
+function resolveSemanticDiagnostics(options, payload) {
+  const semantic = options && options.semanticValidation ? options.semanticValidation : null;
+  if (!semantic) return [];
+  try {
+    if (typeof semantic === 'function') {
+      return normalizeSemanticDiagnostics(semantic(payload));
+    }
+  } catch (e) {}
+  try {
+    if (semantic && typeof semantic.getDiagnostics === 'function') {
+      return normalizeSemanticDiagnostics(semantic.getDiagnostics(payload));
+    }
+  } catch (e) {}
+  try {
+    if (semantic && semantic.kind === 'xray-routing') {
+      return normalizeSemanticDiagnostics(validateXrayRoutingSemantics(payload.data, semantic.options || {}));
+    }
+  } catch (e) {}
+  return [];
+}
+
 /**
  * Parse JSON from editor, with fallback for partial content
  */
@@ -655,6 +682,14 @@ function jsonSchemaLinter(options) {
 
     const pointerMap = buildPointerMap(view.state);
     const schemaErrors = validateValue(data, schema, schema, '');
+    const semanticErrors = resolveSemanticDiagnostics(options, {
+      data,
+      text,
+      schema,
+      pointerMap,
+      state: view.state,
+      doc: view.state.doc,
+    });
 
     // Map pointer-based errors to document positions
     const diagnostics = [];
@@ -689,6 +724,29 @@ function jsonSchemaLinter(options) {
         severity: 'warning',
         message,
         source: schema.title || 'json-schema',
+      });
+    }
+
+    for (const err of semanticErrors) {
+      const pointer = err.pointer || '';
+      const mapping = findDiagnosticMapping(pointerMap, pointer);
+      let from = 0;
+      let to = 0;
+      if (mapping) {
+        if (mapping.valueFrom !== undefined && mapping.valueTo !== undefined) {
+          from = mapping.valueFrom;
+          to = mapping.valueTo;
+        } else {
+          from = mapping.keyFrom;
+          to = mapping.keyTo;
+        }
+      }
+      diagnostics.push({
+        from,
+        to,
+        severity: err.severity === 'warning' ? 'warning' : 'error',
+        message: withDiagnosticContext(err.message, pointer, view.state.doc, mapping),
+        source: err.source || 'semantic-validation',
       });
     }
 
@@ -1625,6 +1683,10 @@ export {
   updateSchema,
   getJSONSchema,
   schemaStateField,
+  buildJsoncPointerMap,
+  findDiagnosticMapping,
+  withDiagnosticContext,
+  safeParseJson,
   jsonSchemaLinter,
   handleRefresh,
   jsonSchemaHover,


### PR DESCRIPTION
## What changed
- add schema semantic validation for Xray and Mihomo config editing flows
- add task-oriented snippets and block templates, then wire them into routing, JSON modal, and Mihomo editors
- document Keenetic caveats so Mihomo DNS/TUN and Xray DNS do not look like default baseline paths
- add runtime tests for snippet resolution/completion and keep the frontend build green

## Why
Schema assistance was still mostly syntax-first, and the Phase 3 snippet catalog was not fully wired into the real editor flows. This left users manually assembling common blocks and made Keenetic-specific DNS/TUN paths look more standard than they really are.

## Impact
- config editors now catch more semantic mistakes before save
- users can insert working scaffolds directly from completion in Monaco, CM6, and YAML assist
- Keenetic users get clearer warnings around non-default DNS/TUN setup paths

## Validation
- `python -m pytest tests/test_schema_snippets_runtime.py tests/test_codemirror_json_schema_completion_runtime.py tests/test_mihomo_yaml_schema_runtime.py -q`
- `npm.cmd run frontend:build`