### PR TITLE
[codex] Expand restart log events

### DIFF
--- a/tests/test_restart_log_subscription_ux.py
+++ b/tests/test_restart_log_subscription_ux.py
@@ -16,10 +16,14 @@ def test_restart_log_formats_subscription_refresh_entries_and_polls_for_updates(
 
     assert "const RESTART_LOG_POLL_MS = 15000;" in restart_log_src
     assert "'xray-subscription-refresh': {" in restart_log_src
+    assert "'core-switch': {" in restart_log_src
+    assert "parseRestartMeta" in restart_log_src
+    assert "цель: ${core}" in restart_log_src
     assert "label: 'Подписка Xray'" in restart_log_src
     assert "showSubscriptionRefreshToast" in restart_log_src
     assert "toastNewSubscription" in restart_log_src
     assert "restart-log-pill-subscription" in styles_src
+    assert "restart-log-pill-core" in styles_src
     assert ".log-card .log-line-success" in styles_src
 
 

--- a/tests/test_xkeen_service_control_fallback.py
+++ b/tests/test_xkeen_service_control_fallback.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from flask import Flask
+
 from services import xkeen as xkeen_service
 
 
@@ -81,6 +83,36 @@ def test_service_routes_use_verified_control_helper_for_start_and_stop():
     assert 'ok = control_xkeen_action("stop", prefer_init=True)' in text
     assert 'subprocess.check_call(build_xkeen_cmd("-start"))' not in text
     assert 'subprocess.check_call(build_xkeen_cmd("-stop"))' not in text
+
+
+def test_core_switch_route_writes_restart_log_entry_with_metadata(monkeypatch, tmp_path):
+    from routes import service
+
+    seen: list[tuple[bool, str, dict[str, object]]] = []
+
+    monkeypatch.setattr(service, 'get_cores_status', lambda: (['xray', 'mihomo'], 'xray'))
+    monkeypatch.setattr(service, 'switch_core', lambda core, error_log: None)
+
+    app = Flask('service-core-switch-log')
+    app.register_blueprint(
+        service.create_service_blueprint(
+            restart_xkeen=lambda **_kwargs: True,
+            append_restart_log=lambda ok, source='api', **meta: seen.append((ok, source, meta)),
+            XRAY_ERROR_LOG=str(tmp_path / 'xray-error.log'),
+        )
+    )
+
+    response = app.test_client().post('/api/xkeen/core', json={'core': 'mihomo'})
+
+    assert response.status_code == 200
+    assert response.get_json()['restarted'] is True
+    assert seen
+    ok, source, meta = seen[-1]
+    assert ok is True
+    assert source == 'core-switch'
+    assert meta['core'] == 'mihomo'
+    assert meta['previous'] == 'xray'
+    assert isinstance(meta['duration_ms'], int)
 
 
 def test_service_status_restart_button_uses_background_restart_job_with_pty_log_stream():

--- a/xkeen-ui/app_factory.py
+++ b/xkeen-ui/app_factory.py
@@ -462,8 +462,8 @@ def create_app(*, ws_runtime: bool = False):
     from services.restart_log import clear_restart_log as _svc_clear_restart_log
     from services.xray import restart_xray_core as _svc_restart_xray_core
 
-    def append_restart_log(ok, source: str = "api"):
-        return _svc_append_restart_log(RESTART_LOG_FILE, ok, source=source)
+    def append_restart_log(ok, source: str = "api", **meta):
+        return _svc_append_restart_log(RESTART_LOG_FILE, ok, source=source, **meta)
 
     def read_restart_log(limit: int = 100):
         return _svc_read_restart_log(RESTART_LOG_FILE, limit=limit)

--- a/xkeen-ui/routes/service.py
+++ b/xkeen-ui/routes/service.py
@@ -1,6 +1,7 @@
 """Service-control API routes for xkeen as a Flask Blueprint."""
 from __future__ import annotations
 import subprocess
+import time
 
 from flask import Blueprint, request, jsonify
 from typing import Any, Callable
@@ -41,7 +42,7 @@ from services.cores import CoreSwitchError, get_cores_status, switch_core
 
 def create_service_blueprint(
     restart_xkeen: Callable[..., bool],
-    append_restart_log: Callable[[str, bool, str], None] | Callable[..., None],
+    append_restart_log: Callable[..., None],
     XRAY_ERROR_LOG: str,
     broadcast_event: Callable[[dict], None] | None = None,
     read_restart_log: Callable[..., list[str]] | None = None,
@@ -106,6 +107,50 @@ def create_service_blueprint(
         def clear_restart_log():  # type: ignore[no-redef]
             return None
 
+    def _append_restart_log(ok: bool, source: str = "api", **meta: object) -> None:
+        try:
+            append_restart_log(ok, source=source, **meta)
+        except TypeError:
+            try:
+                append_restart_log(ok, source=source)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    def _restart_log_elapsed_ms(started_at: float) -> int:
+        try:
+            return max(0, int(round((time.monotonic() - started_at) * 1000)))
+        except Exception:
+            return 0
+
+    def _detect_core_for_restart_log() -> str:
+        try:
+            _, current_core = get_cores_status()
+            return str(current_core or "")
+        except Exception:
+            return ""
+
+    def _core_switch_meta(
+        *,
+        core: str,
+        previous_core: str,
+        started_at: float,
+        phase: str = "",
+        returncode: object = None,
+    ) -> dict[str, object]:
+        meta: dict[str, object] = {
+            "core": core or "unknown",
+            "duration_ms": _restart_log_elapsed_ms(started_at),
+        }
+        if previous_core:
+            meta["previous"] = previous_core
+        if phase:
+            meta["phase"] = phase
+        if returncode is not None:
+            meta["returncode"] = returncode
+        return meta
+
     @bp.get("/api/restart-log")
     def api_restart_log() -> Any:
         try:
@@ -138,14 +183,14 @@ def create_service_blueprint(
     def api_xkeen_start() -> Any:
         try:
             ok = control_xkeen_action("start", prefer_init=True)
-            append_restart_log(ok, source="api-start")
+            _append_restart_log(ok, source="api-start")
             if ok:
                 _core_log("info", "xkeen.start", source="api-start")
                 return jsonify({"ok": True}), 200
             _core_log("error", "xkeen.start_failed", source="api-start")
             return jsonify({"ok": False}), 500
         except Exception:
-            append_restart_log(False, source="api-start")
+            _append_restart_log(False, source="api-start")
             _core_log("error", "xkeen.start_failed", source="api-start")
             return jsonify({"ok": False}), 500
 
@@ -154,14 +199,14 @@ def create_service_blueprint(
     def api_xkeen_stop() -> Any:
         try:
             ok = control_xkeen_action("stop", prefer_init=True)
-            append_restart_log(ok, source="api-stop")
+            _append_restart_log(ok, source="api-stop")
             if ok:
                 _core_log("info", "xkeen.stop", source="api-stop")
                 return jsonify({"ok": True}), 200
             _core_log("error", "xkeen.stop_failed", source="api-stop")
             return jsonify({"ok": False}), 500
         except Exception:
-            append_restart_log(False, source="api-stop")
+            _append_restart_log(False, source="api-stop")
             _core_log("error", "xkeen.stop_failed", source="api-stop")
             return jsonify({"ok": False}), 500
 
@@ -261,12 +306,25 @@ def create_service_blueprint(
     def api_xkeen_core_set() -> Any:
         """Смена ядра xkeen через сервисный модуль (switch_core)."""
         core = ""
+        started_at = time.monotonic()
+        previous_core = ""
         try:
             payload = request.get_json(silent=True) or {}
             core = str(payload.get("core", "")).strip()
+            previous_core = _detect_core_for_restart_log()
             try:
                 switch_core(core, XRAY_ERROR_LOG)
             except ValueError:
+                _append_restart_log(
+                    False,
+                    source="core-switch",
+                    **_core_switch_meta(
+                        core=core,
+                        previous_core=previous_core,
+                        started_at=started_at,
+                        phase="validate",
+                    ),
+                )
                 return _service_error(
                     "Недопустимое ядро.",
                     400,
@@ -274,6 +332,18 @@ def create_service_blueprint(
                     hint="Укажите допустимое ядро: xray или mihomo.",
                 )
             except CoreSwitchError as e:
+                details = e.details or {}
+                _append_restart_log(
+                    False,
+                    source="core-switch",
+                    **_core_switch_meta(
+                        core=core,
+                        previous_core=previous_core,
+                        started_at=started_at,
+                        phase=str(details.get("phase") or ""),
+                        returncode=details.get("returncode"),
+                    ),
+                )
                 _core_log("error", "xkeen.core_set_failed", core=core, error=str(e), **(e.details or {}))
                 return _service_exception(
                     "Не удалось переключить ядро xkeen.",
@@ -283,6 +353,16 @@ def create_service_blueprint(
                     log_extra={"core": core},
                 )
             except RuntimeError as e:
+                _append_restart_log(
+                    False,
+                    source="core-switch",
+                    **_core_switch_meta(
+                        core=core,
+                        previous_core=previous_core,
+                        started_at=started_at,
+                        phase="runtime",
+                    ),
+                )
                 _core_log("error", "xkeen.core_set_failed", core=core, error=str(e))
                 return _service_exception(
                     "Не удалось переключить ядро xkeen.",
@@ -295,10 +375,29 @@ def create_service_blueprint(
             # Уведомляем всех WS-подписчиков о смене ядра.
             _emit_event({"event": "core_changed", "core": core, "ok": True})
 
+            _append_restart_log(
+                True,
+                source="core-switch",
+                **_core_switch_meta(
+                    core=core,
+                    previous_core=previous_core,
+                    started_at=started_at,
+                ),
+            )
             _core_log("info", "xkeen.core_set", core=core)
-            return jsonify({"ok": True, "core": core}), 200
+            return jsonify({"ok": True, "core": core, "restarted": True}), 200
         except Exception as e:
             _emit_event({"event": "core_change_error", "core": core, "ok": False, "error": "core_switch_failed"})
+            _append_restart_log(
+                False,
+                source="core-switch",
+                **_core_switch_meta(
+                    core=core,
+                    previous_core=previous_core,
+                    started_at=started_at,
+                    phase="exception",
+                ),
+            )
             return _service_exception(
                 "Не удалось переключить ядро xkeen.",
                 code="core_switch_failed",

--- a/xkeen-ui/services/restart_log.py
+++ b/xkeen-ui/services/restart_log.py
@@ -5,16 +5,48 @@ Keeps read/clear operations out of app.py. The log file path is passed in explic
 from __future__ import annotations
 
 import os
+import re
 import time
+from urllib.parse import quote
 from typing import List
 
 
-def append_restart_log(log_file: str, ok: bool, source: str = "api") -> None:
+_META_KEY_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _format_meta_key(key: object) -> str:
+    raw = str(key or "").strip().lower()
+    raw = _META_KEY_RE.sub("_", raw).strip("_.-")
+    return raw[:48]
+
+
+def _format_meta_value(value: object) -> str:
+    raw = str(value if value is not None else "").strip()
+    if len(raw) > 160:
+        raw = raw[:157] + "..."
+    return quote(raw, safe="-._:/")
+
+
+def _format_restart_meta(meta: dict[str, object]) -> str:
+    parts: list[str] = []
+    for key, value in (meta or {}).items():
+        meta_key = _format_meta_key(key)
+        if not meta_key or value is None:
+            continue
+        meta_value = _format_meta_value(value)
+        if not meta_value:
+            continue
+        parts.append(f"{meta_key}={meta_value}")
+    return (" " + " ".join(parts)) if parts else ""
+
+
+def append_restart_log(log_file: str, ok: bool, source: str = "api", **meta: object) -> None:
     """Append a single line about restart result to the restart log."""
-    line = "[{ts}] source={src} result={res}\n".format(
+    line = "[{ts}] source={src} result={res}{meta}\n".format(
         ts=time.strftime("%Y-%m-%d %H:%M:%S"),
-        src=source,
+        src=_format_meta_value(source or "api") or "api",
         res="OK" if ok else "FAIL",
+        meta=_format_restart_meta(meta),
     )
     log_dir = os.path.dirname(log_file)
     if log_dir and not os.path.isdir(log_dir):

--- a/xkeen-ui/services/xkeen.py
+++ b/xkeen-ui/services/xkeen.py
@@ -2,42 +2,23 @@
 
 from __future__ import annotations
 
-import os
 import time
 import subprocess
 from typing import Iterable, List, Sequence
 
+from services.restart_log import append_restart_log as _append_restart_log
+from services.restart_log import read_restart_log as _read_restart_log
 from services.xkeen_commands_catalog import build_xkeen_cmd, resolve_xkeen_init_script
 
 
-def append_restart_log(log_file: str, ok: bool, source: str = "api") -> None:
+def append_restart_log(log_file: str, ok: bool, source: str = "api", **meta: object) -> None:
     """Append a single line about restart result to the restart log."""
-    line = "[{ts}] source={src} result={res}\n".format(
-        ts=time.strftime("%Y-%m-%d %H:%M:%S"),
-        src=source,
-        res="OK" if ok else "FAIL",
-    )
-    log_dir = os.path.dirname(log_file)
-    if log_dir and not os.path.isdir(log_dir):
-        os.makedirs(log_dir, exist_ok=True)
-    try:
-        with open(log_file, "a") as f:
-            f.write(line)
-    except Exception:
-        # Logging errors are non-critical
-        pass
+    return _append_restart_log(log_file, ok, source=source, **meta)
 
 
 def read_restart_log(log_file: str, limit: int = 100) -> List[str]:
     """Read last ``limit`` lines from restart log file, if it exists."""
-    if not os.path.isfile(log_file):
-        return []
-    try:
-        with open(log_file, "r") as f:
-            lines = f.readlines()
-        return lines[-limit:]
-    except Exception:
-        return []
+    return _read_restart_log(log_file, limit=limit)
 
 
 def is_xkeen_running() -> bool:

--- a/xkeen-ui/static/js/features/restart_log.js
+++ b/xkeen-ui/static/js/features/restart_log.js
@@ -15,12 +15,18 @@ let restartLogModuleApi = null;
   RL._pollTimer = RL._pollTimer || null;
 
   const RESTART_LOG_POLL_MS = 15000;
-  const RESTART_SUMMARY_RE = /^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]\s+source=([^\s]+)\s+result=([A-Z]+)\s*$/i;
+  const RESTART_SUMMARY_RE = /^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]\s+source=([^\s]+)\s+result=([A-Z]+)(?:\s+(.*?))?\s*$/i;
   const RESTART_SOURCE_META = Object.freeze({
     api: {
       label: 'Xkeen',
       successText: 'перезапущен успешно',
       failureText: 'перезапуск завершился ошибкой',
+      bucket: 'service',
+    },
+    'api-button': {
+      label: 'Xkeen',
+      successText: 'перезапущен вручную',
+      failureText: 'ручной перезапуск завершился ошибкой',
       bucket: 'service',
     },
     'api-start': {
@@ -35,11 +41,101 @@ let restartLogModuleApi = null;
       failureText: 'не удалось остановить',
       bucket: 'service',
     },
+    'core-switch': {
+      label: 'Ядро Xkeen',
+      successText: 'ядро переключено, xkeen перезапущен',
+      failureText: 'смена ядра завершилась ошибкой',
+      bucket: 'core',
+    },
+    routing: {
+      label: 'Routing',
+      successText: 'сохранён, xkeen перезапущен',
+      failureText: 'сохранён, но перезапуск xkeen завершился ошибкой',
+      bucket: 'routing',
+    },
+    inbounds: {
+      label: 'Inbounds',
+      successText: 'сохранены, xkeen перезапущен',
+      failureText: 'сохранены, но перезапуск xkeen завершился ошибкой',
+      bucket: 'xray',
+    },
+    outbounds: {
+      label: 'Outbounds',
+      successText: 'сохранены, xkeen перезапущен',
+      failureText: 'сохранены, но перезапуск xkeen завершился ошибкой',
+      bucket: 'xray',
+    },
+    'observatory-preset': {
+      label: 'Observatory',
+      successText: 'пресет применён, xkeen перезапущен',
+      failureText: 'пресет применён, но перезапуск xkeen завершился ошибкой',
+      bucket: 'xray',
+    },
     'mihomo-config': {
       label: 'Mihomo',
       successText: 'конфиг применён, xkeen перезапущен',
       failureText: 'конфиг применён, но перезапуск xkeen завершился ошибкой',
       bucket: 'mihomo',
+    },
+    'mihomo-profile-activate': {
+      label: 'Mihomo',
+      successText: 'профиль активирован, xkeen перезапущен',
+      failureText: 'профиль активирован, но перезапуск xkeen завершился ошибкой',
+      bucket: 'mihomo',
+    },
+    'mihomo-backup-restore': {
+      label: 'Mihomo',
+      successText: 'бэкап восстановлен, xkeen перезапущен',
+      failureText: 'бэкап восстановлен, но перезапуск xkeen завершился ошибкой',
+      bucket: 'mihomo',
+    },
+    'manual-mihomo': {
+      label: 'Xkeen',
+      successText: 'перезапущен вручную',
+      failureText: 'ручной перезапуск завершился ошибкой',
+      bucket: 'service',
+    },
+    'snapshot-restore': {
+      label: 'Бэкап',
+      successText: 'восстановлен, xkeen перезапущен',
+      failureText: 'восстановлен, но перезапуск xkeen завершился ошибкой',
+      bucket: 'backup',
+    },
+    'backups-page': {
+      label: 'Бэкап',
+      successText: 'операция выполнена, xkeen перезапущен',
+      failureText: 'операция выполнена, но перезапуск xkeen завершился ошибкой',
+      bucket: 'backup',
+    },
+    'port-proxying': {
+      label: 'Port proxying',
+      successText: 'список сохранён, xkeen перезапущен',
+      failureText: 'список сохранён, но перезапуск xkeen завершился ошибкой',
+      bucket: 'service',
+    },
+    'port-exclude': {
+      label: 'Port exclude',
+      successText: 'список сохранён, xkeen перезапущен',
+      failureText: 'список сохранён, но перезапуск xkeen завершился ошибкой',
+      bucket: 'service',
+    },
+    'ip-exclude': {
+      label: 'IP exclude',
+      successText: 'список сохранён, xkeen перезапущен',
+      failureText: 'список сохранён, но перезапуск xkeen завершился ошибкой',
+      bucket: 'service',
+    },
+    'xkeen-config': {
+      label: 'xkeen.json',
+      successText: 'сохранён, xkeen перезапущен',
+      failureText: 'сохранён, но перезапуск xkeen завершился ошибкой',
+      bucket: 'service',
+    },
+    'xray-subscription-delete': {
+      label: 'Подписка Xray',
+      successText: 'удалена, xkeen перезапущен',
+      failureText: 'удалена, но перезапуск xkeen завершился ошибкой',
+      bucket: 'subscription',
     },
     'xray-subscription-refresh': {
       label: 'Подписка Xray',
@@ -79,6 +175,79 @@ let restartLogModuleApi = null;
     return titleCaseWords(raw.replace(/[-_]+/g, ' '));
   }
 
+  function decodeRestartMetaValue(value) {
+    const raw = String(value || '');
+    if (!raw) return '';
+    try {
+      return decodeURIComponent(raw.replace(/\+/g, '%20'));
+    } catch (error) {
+      return raw;
+    }
+  }
+
+  function parseRestartMeta(rawText) {
+    const text = String(rawText || '').trim();
+    if (!text) return {};
+
+    const out = {};
+    const re = /([A-Za-z0-9_.-]+)=([^\s]+)/g;
+    let match = null;
+    while ((match = re.exec(text))) {
+      const key = String(match[1] || '').trim();
+      if (!key) continue;
+      out[key] = decodeRestartMetaValue(match[2]);
+    }
+    return out;
+  }
+
+  function humanCoreName(core) {
+    const value = String(core || '').trim().toLowerCase();
+    if (value === 'xray') return 'Xray';
+    if (value === 'mihomo') return 'Mihomo';
+    if (value === 'unknown') return 'неизвестно';
+    return value ? titleCaseWords(value.replace(/[-_]+/g, ' ')) : '';
+  }
+
+  function formatDurationMs(value) {
+    const ms = Number(value);
+    if (!Number.isFinite(ms) || ms <= 0) return '';
+    if (ms >= 1000) {
+      const seconds = ms / 1000;
+      return `${seconds.toFixed(seconds >= 10 ? 0 : 1)}с`;
+    }
+    return `${Math.round(ms)}мс`;
+  }
+
+  function formatRestartMetaDetails(source, details) {
+    const meta = details && typeof details === 'object' ? details : {};
+    const parts = [];
+
+    if (source === 'core-switch') {
+      const core = humanCoreName(meta.core);
+      const previous = humanCoreName(meta.previous);
+      if (core) parts.push(`цель: ${core}`);
+      if (previous && previous !== core) parts.push(`было: ${previous}`);
+      if (meta.phase) parts.push(`этап: ${meta.phase}`);
+      if (meta.returncode) parts.push(`код: ${meta.returncode}`);
+    }
+
+    const duration = formatDurationMs(meta.duration_ms);
+    if (duration) parts.push(duration);
+
+    return parts.join(' · ');
+  }
+
+  function buildRestartSummaryMessage(source, ok, baseMessage, details) {
+    const message = String(baseMessage || '');
+    if (source !== 'core-switch') return message;
+
+    const core = humanCoreName(details && details.core);
+    if (!core) return message;
+    return ok
+      ? `переключено на ${core}, xkeen перезапущен`
+      : `не удалось переключить на ${core}`;
+  }
+
   function parseStructuredRestartLine(line) {
     const raw = String(line || '');
     if (!raw) return null;
@@ -87,23 +256,27 @@ let restartLogModuleApi = null;
     if (!match) return null;
 
     const ts = String(match[1] || '').trim();
-    const source = String(match[2] || '').trim();
+    const source = decodeRestartMetaValue(match[2] || '').trim();
     const result = String(match[3] || '').trim().toUpperCase();
+    const details = parseRestartMeta(match[4] || '');
     const ok = result === 'OK';
     const meta = RESTART_SOURCE_META[source] || null;
     const label = meta && meta.label ? meta.label : fallbackRestartSourceLabel(source);
-    const message = ok
+    const baseMessage = ok
       ? (meta && meta.successText ? meta.successText : 'операция завершилась успешно')
       : (meta && meta.failureText ? meta.failureText : 'операция завершилась с ошибкой');
+    const message = buildRestartSummaryMessage(source, ok, baseMessage, details);
     const kind = ok ? 'success' : 'error';
     const bucket = meta && meta.bucket ? meta.bucket : 'generic';
-    const copyText = `[${ts}] ${label} — ${message}`;
-    const rawSourceText = meta ? '' : `Источник: ${source}`;
+    const detailsText = formatRestartMetaDetails(source, details);
+    const copyText = `[${ts}] ${label} — ${message}${detailsText ? ` · ${detailsText}` : ''}`;
+    const rawSourceText = detailsText || (meta ? '' : `Источник: ${source}`);
 
     return {
       ts,
       source,
       result,
+      details,
       ok,
       kind,
       bucket,
@@ -585,13 +758,17 @@ let restartLogModuleApi = null;
           bindOnce(btn, (event) => { event.preventDefault(); RL.clear(); });
         } else if (action === 'copy') {
           bindOnce(btn, (event) => { event.preventDefault(); RL.copy(); });
+        } else if (action === 'refresh') {
+          bindOnce(btn, (event) => { event.preventDefault(); RL.load({ toastNewSubscription: false }); });
         }
       });
     } catch (error) {}
 
     try {
+      const refreshBtn = document.getElementById('restart-log-refresh-btn');
       const clearBtn = document.getElementById('restart-log-clear-btn');
       const copyBtn = document.getElementById('restart-log-copy-btn');
+      bindOnce(refreshBtn, (event) => { event.preventDefault(); RL.load({ toastNewSubscription: false }); });
       bindOnce(clearBtn, (event) => { event.preventDefault(); RL.clear(); });
       bindOnce(copyBtn, (event) => { event.preventDefault(); RL.copy(); });
     } catch (error) {}

--- a/xkeen-ui/static/js/ui/spinner_fetch.js
+++ b/xkeen-ui/static/js/ui/spinner_fetch.js
@@ -287,9 +287,22 @@
       return;
     }
 
+    function refreshRestartLogSoon() {
+      try {
+        setTimeout(function () {
+          import('../features/restart_log.js').then(function (mod) {
+            if (mod && typeof mod.loadRestartLog === 'function') {
+              mod.loadRestartLog({ toastNewSubscription: false, silent: true });
+            }
+          }).catch(function () {});
+        }, 300);
+      } catch (e) {}
+    }
+
     try {
       response.clone().json().then(function (data) {
         if (!data || !data.restarted) return;
+        refreshRestartLogSoon();
 
         // Unified "restart + context" toast to avoid duplicates across modules.
         const msg = restartToastMessageForUrl(url);

--- a/xkeen-ui/static/styles.css
+++ b/xkeen-ui/static/styles.css
@@ -5309,7 +5309,7 @@ html[data-theme="light"] .xray-log-select option{
   background: rgba(15, 23, 42, 0.42);
   font-size: 0.92em;
   font-weight: 700;
-  letter-spacing: 0.01em;
+  letter-spacing: 0;
 }
 
 .log-card .restart-log-pill-subscription {
@@ -5328,6 +5328,30 @@ html[data-theme="light"] .xray-log-select option{
   border-color: color-mix(in srgb, var(--sem-warning, #fbbf24) 38%, transparent);
   background: color-mix(in srgb, var(--sem-warning, #fbbf24) 14%, rgba(15, 23, 42, 0.78));
   color: color-mix(in srgb, var(--sem-warning, #fbbf24) 84%, white 16%);
+}
+
+.log-card .restart-log-pill-core {
+  border-color: color-mix(in srgb, var(--accent, #38bdf8) 40%, transparent);
+  background: color-mix(in srgb, var(--accent, #38bdf8) 15%, rgba(15, 23, 42, 0.78));
+  color: color-mix(in srgb, var(--accent, #38bdf8) 84%, white 16%);
+}
+
+.log-card .restart-log-pill-routing {
+  border-color: color-mix(in srgb, var(--sem-info, #93c5fd) 34%, transparent);
+  background: color-mix(in srgb, var(--sem-info, #93c5fd) 12%, rgba(15, 23, 42, 0.78));
+  color: color-mix(in srgb, var(--sem-info, #93c5fd) 82%, white 18%);
+}
+
+.log-card .restart-log-pill-xray {
+  border-color: color-mix(in srgb, var(--sem-success, #4ade80) 32%, transparent);
+  background: color-mix(in srgb, var(--sem-success, #4ade80) 12%, rgba(15, 23, 42, 0.78));
+  color: color-mix(in srgb, var(--sem-success, #4ade80) 82%, white 18%);
+}
+
+.log-card .restart-log-pill-backup {
+  border-color: color-mix(in srgb, var(--sem-debug, #a1a1aa) 36%, transparent);
+  background: color-mix(in srgb, var(--sem-debug, #a1a1aa) 13%, rgba(15, 23, 42, 0.78));
+  color: color-mix(in srgb, var(--sem-debug, #a1a1aa) 86%, white 14%);
 }
 
 .log-card .restart-log-pill-generic {
@@ -5366,6 +5390,30 @@ html[data-theme="light"] .log-card .restart-log-pill-mihomo {
   border-color: color-mix(in srgb, var(--sem-warning, #d97706) 24%, rgba(15, 23, 42, 0.08));
   background: color-mix(in srgb, var(--sem-warning, #d97706) 10%, white 90%);
   color: color-mix(in srgb, var(--sem-warning, #d97706) 82%, #78350f 18%);
+}
+
+html[data-theme="light"] .log-card .restart-log-pill-core {
+  border-color: color-mix(in srgb, var(--accent, #0284c7) 26%, rgba(15, 23, 42, 0.08));
+  background: color-mix(in srgb, var(--accent, #0284c7) 10%, white 90%);
+  color: color-mix(in srgb, var(--accent, #0284c7) 82%, #0c4a6e 18%);
+}
+
+html[data-theme="light"] .log-card .restart-log-pill-routing {
+  border-color: color-mix(in srgb, var(--sem-info, #2563eb) 22%, rgba(15, 23, 42, 0.08));
+  background: color-mix(in srgb, var(--sem-info, #2563eb) 8%, white 92%);
+  color: color-mix(in srgb, var(--sem-info, #2563eb) 78%, #1e3a8a 22%);
+}
+
+html[data-theme="light"] .log-card .restart-log-pill-xray {
+  border-color: color-mix(in srgb, var(--sem-success, #16a34a) 22%, rgba(15, 23, 42, 0.08));
+  background: color-mix(in srgb, var(--sem-success, #16a34a) 8%, white 92%);
+  color: color-mix(in srgb, var(--sem-success, #16a34a) 78%, #14532d 22%);
+}
+
+html[data-theme="light"] .log-card .restart-log-pill-backup {
+  border-color: color-mix(in srgb, var(--sem-debug, #64748b) 22%, rgba(15, 23, 42, 0.08));
+  background: color-mix(in srgb, var(--sem-debug, #64748b) 8%, white 92%);
+  color: color-mix(in srgb, var(--sem-debug, #64748b) 76%, #334155 24%);
 }
 
 

--- a/xkeen-ui/templates/panel.html
+++ b/xkeen-ui/templates/panel.html
@@ -848,6 +848,7 @@
           <div class="log-header-row">
             <h2>Журнал перезапуска</h2>
             <div class="log-header-actions">
+              <button type="button" class="btn-secondary log-btn" data-xk-restart-log-action="refresh">Обновить</button>
               <button type="button" class="btn-secondary log-btn" data-xk-restart-log-action="clear">Очистить</button>
               <button type="button" class="btn-secondary log-btn" data-xk-restart-log-action="copy">Копировать</button>
             </div>
@@ -1110,6 +1111,7 @@
     <div class="log-header-row">
       <h2>Журнал перезапуска</h2>
       <div class="log-header-actions">
+        <button type="button" class="btn-secondary log-btn" data-xk-restart-log-action="refresh">Обновить</button>
         <button type="button" class="btn-secondary log-btn" data-xk-restart-log-action="clear">Очистить</button>
         <button type="button" class="btn-secondary log-btn" data-xk-restart-log-action="copy">Копировать</button>
       </div>
@@ -1365,8 +1367,9 @@
   <!-- Restart log -->
     <section class="card log-card">
       <div class="log-header-row">
-        <h2>Журнал</h2>
+        <h2>Журнал перезапуска</h2>
         <div class="log-header-actions">
+          <button type="button" class="btn-secondary log-btn" id="restart-log-refresh-btn" data-xk-restart-log-action="refresh">Обновить</button>
           <button type="button" class="btn-secondary log-btn" id="restart-log-clear-btn" data-xk-restart-log-action="clear">Очистить</button>
           <button type="button" class="btn-secondary log-btn" id="restart-log-copy-btn" data-xk-restart-log-action="copy">Копировать</button>
         </div>


### PR DESCRIPTION
## What changed
- Logged core switches into the restart log with target core, previous core, duration, and failure phase metadata.
- Expanded restart-log rendering with friendly labels for core switches, routing, Xray, Mihomo, backups, lists, and subscriptions.
- Added manual refresh controls and immediate restart-log refresh after successful restart responses.

## Why
Core switching restarts xkeen but previously left the restart journal empty, making the operation hard to audit from the UI.

## Validation
- pytest tests/test_xkeen_service_control_fallback.py tests/test_restart_log_subscription_ux.py tests/test_exception_detail_sanitization.py::test_service_core_switch_hides_exception_details
- python3 -m py_compile xkeen-ui/services/restart_log.py xkeen-ui/services/xkeen.py xkeen-ui/routes/service.py xkeen-ui/app_factory.py
- node --check xkeen-ui/static/js/features/restart_log.js && node --check xkeen-ui/static/js/ui/spinner_fetch.js
- npm run frontend:build
- npm run frontend:verify:static
